### PR TITLE
chore: Remove useless test

### DIFF
--- a/tests/Controller/LdapDropdownControllerTest.php
+++ b/tests/Controller/LdapDropdownControllerTest.php
@@ -130,13 +130,6 @@ final class LdapDropdownControllerTest extends AdvancedFormsTestCase
         ]);
     }
 
-    private function testWithInvalidForm(): void
-    {
-        $this->enableConfigurableItem(LdapQuestion::class);
-        $ldap = $this->setupAuthLdap();
-        $form = $this->createFormWithLdapQuestion($ldap);
-    }
-
     private function renderRoute(array $post): Response
     {
         $controller = new LdapDropdownController();


### PR DESCRIPTION
This pull request makes a minor change to the test suite by removing an unused private helper method from `LdapDropdownControllerTest.php`. This helps to clean up the code and improve maintainability.