### PR TITLE
fix: Update security policy for ldap dropdown controller

### DIFF
--- a/src/Controller/LdapDropdownController.php
+++ b/src/Controller/LdapDropdownController.php
@@ -37,6 +37,8 @@ use Glpi\Controller\AbstractController;
 use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Form\Question;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
 use GlpiPlugin\Advancedforms\Model\Dropdown\LdapDropdown;
 use GlpiPlugin\Advancedforms\Model\Dropdown\LdapDropdownQuery;
 use GlpiPlugin\Advancedforms\Utils\SafeCommonDBTM;
@@ -53,6 +55,7 @@ final class LdapDropdownController extends AbstractController
 {
     use CanCheckAccessPolicies;
 
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
     #[Route(
         path: 'LdapDropdown',
         name: "ldap_dropdown",


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.

## Description

- It fixes #3 

This PR fixes an issue related to the user interface that made LDAP questions non-functional for self-service users.
The addition of the authenticated strategy replaces the default strategy: `STRATEGY_CENTRAL_ACCESS`