### PR TITLE
fix(ldap-select): Filter ldap dropdown entries with search text

### DIFF
--- a/src/Controller/LdapDropdownController.php
+++ b/src/Controller/LdapDropdownController.php
@@ -93,7 +93,7 @@ final class LdapDropdownController extends AbstractController
         $this->checkFormAccessPolicies($question->getForm(), $request);
 
         // Read others parameters
-        $search_text = $request->request->getString('');
+        $search_text = $request->request->getString('searchText', '');
         $page        = $request->request->getInt('page', 0);
         $page_limit  = $request->request->getInt('page_limit', 0);
 

--- a/tests/Controller/LdapDropdownControllerTest.php
+++ b/tests/Controller/LdapDropdownControllerTest.php
@@ -130,6 +130,64 @@ final class LdapDropdownControllerTest extends AdvancedFormsTestCase
         ]);
     }
 
+    public function testSearchTextParameter(): void
+    {
+        // Arrange: create a valid form
+        $this->enableConfigurableItem(LdapQuestion::class);
+        $ldap = $this->setupAuthLdap();
+        $form = $this->createFormWithLdapQuestion($ldap);
+
+        // Act: execute route with searchText
+        $this->login('post-only');
+        $response = $this->renderRoute([
+            'condition'  => $this->buildAndGetConditionUuid($form),
+            'page'       => 1,
+            'page_limit' => 10,
+            'searchText' => 'pierre',
+        ]);
+
+        // Assert: response should be successful
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Assert: response should be valid JSON
+        $content = $response->getContent();
+        $this->assertNotFalse($content);
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('results', $data);
+        $this->assertArrayHasKey('count', $data);
+        $this->assertEquals([['id' => 'pierre', 'text' => 'pierre']], $data['results']);
+    }
+
+    public function testEmptySearchTextParameter(): void
+    {
+        // Arrange: create a valid form
+        $this->enableConfigurableItem(LdapQuestion::class);
+        $ldap = $this->setupAuthLdap();
+        $form = $this->createFormWithLdapQuestion($ldap);
+
+        // Act: execute route with empty searchText
+        $this->login('post-only');
+        $response = $this->renderRoute([
+            'condition'  => $this->buildAndGetConditionUuid($form),
+            'page'       => 1,
+            'page_limit' => 10,
+            'searchText' => '',
+        ]);
+
+        // Assert: response should be successful
+        $this->assertEquals(200, $response->getStatusCode());
+
+        // Assert: response should be valid JSON
+        $content = $response->getContent();
+        $this->assertNotFalse($content);
+        $data = json_decode($content, true);
+        $this->assertIsArray($data);
+        $this->assertArrayHasKey('results', $data);
+        $this->assertArrayHasKey('count', $data);
+        $this->assertCount(10, $data['results']);
+    }
+
     private function renderRoute(array $post): Response
     {
         $controller = new LdapDropdownController();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [X] I have added tests (when available) that prove my fix is effective or that my feature works.

## Description

- It fixes #9

This pull request improves how the `searchText` parameter is handled in the LDAP dropdown functionality and adds corresponding tests to ensure correct behavior. The main changes involve reading the correct request parameter and verifying expected outcomes through new test cases.

**Improvements to request parameter handling:**

* The `LdapDropdownController` now correctly reads the `searchText` parameter from the request, defaulting to an empty string if not provided.

**Enhancements to test coverage:**

* Added `testSearchTextParameter` to verify that providing a `searchText` value returns the expected filtered results in the response.
* Added `testEmptySearchTextParameter` to ensure that an empty `searchText` returns the expected number of results.