### PR TITLE
Fix treecascade mandatory field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased] -
+
+### Fixed
+
+- Fixed the `Tree cascade Dropdown` field so that it works when it is a required field in single-level responses
+
 ## [1.1.0] - 2026-04-27
 
 ### Add

--- a/templates/tree_cascade_dropdown.html.twig
+++ b/templates/tree_cascade_dropdown.html.twig
@@ -126,6 +126,7 @@
             class="form-select af-tree-cascade-select"
             aria-label="{{ aria_label }}"
             data-af-tree-questions-id="{{ question.fields['id'] }}"
+            data-af-tree-field-name="{{ final_items_id_name }}"
             data-af-tree-ajax-limit="{{ ajax_limit_count }}"
         >
             <option value="0">---</option>


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !44050
- Here is a brief description of what this PR does

There was an issue with a single-level hierarchy in the “Tree cascade dropdown” question type.

When you select one of the available options and submit the form, the field still displays the message “This field is required” if it is a required field and the answer has only one level.

## Screenshots (if appropriate):
