### PR TITLE
Feat - Add configurable table question type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Add
+
+- Add configurable table question type
+
 ### Fixed
 
 - Fixed the `Tree cascade Dropdown` field so that the subtree depth limit is enforced when loading children via AJAX

--- a/public/css/advancedforms.css
+++ b/public/css/advancedforms.css
@@ -33,3 +33,42 @@
 [data-glpi-form-editor-active-question] [data-ldap-question-preview] {
         display: none !important;
 }
+
+/*
+ * GLPI's .select2-selection__rendered has line-height: ~42px + a ::before pseudo-element,
+ * making the total height ~80px while the container is ~40px with overflow:hidden.
+ * When the selection content is a flex span, it gets pushed below the visible area.
+ * Fix applied for both the admin column config panel and the end-user table cells.
+ */
+[data-af-table-column] .select2-selection--single .select2-selection__rendered,
+[data-af-table-question] td .select2-selection--single .select2-selection__rendered {
+    display: flex !important;
+    align-items: center !important;
+    line-height: normal !important;
+    direction: ltr !important;
+    height: 100% !important;
+}
+[data-af-table-column] .select2-selection--single .select2-selection__rendered::before,
+[data-af-table-question] td .select2-selection--single .select2-selection__rendered::before {
+    display: none !important;
+}
+
+/*
+ * Per-cell invalid state for select2 cells.
+ *
+ * Core (_form-renderer.scss) reddens EVERY select2 of a question as soon as one of
+ * its selects is .is-invalid, via a question-level selector:
+ *   [data-glpi-form-renderer-question]:has(select.is-invalid) .select2-selection
+ * A table holds many selects inside a single question, so one invalid cell would turn
+ * every dropdown red. We re-scope the highlight to the offending cell: while the table
+ * has an invalid select, valid cells are reset to the default border, and only the cell
+ * that actually contains the invalid select keeps the red border.
+ *
+ * Plain inputs and checkboxes already get their red border from Bootstrap's .is-invalid.
+ */
+[data-af-table-question]:has(select.is-invalid) td:not(:has(select.is-invalid)) .select2-container--default .select2-selection {
+    border-color: var(--tblr-border-color) !important;
+}
+[data-af-table-question] td:has(select.is-invalid) .select2-container--default .select2-selection {
+    border-color: var(--tblr-form-invalid-border-color) !important;
+}

--- a/public/css/advancedforms.css
+++ b/public/css/advancedforms.css
@@ -34,6 +34,10 @@
         display: none !important;
 }
 
+[data-glpi-form-editor-question]:has([data-af-table-admin]) label.form-check:has([data-glpi-form-editor-original-name="is_mandatory"]) {
+    display: none !important;
+}
+
 [data-af-table-column] .select2-selection--single .select2-selection__rendered,
 [data-af-table-question] td .select2-selection--single .select2-selection__rendered {
     display: flex !important;
@@ -45,6 +49,23 @@
 [data-af-table-column] .select2-selection--single .select2-selection__rendered::before,
 [data-af-table-question] td .select2-selection--single .select2-selection__rendered::before {
     display: none !important;
+}Ptemp
+
+.af-required-toggle {
+    display: inline-flex;
+    align-items: center;
+    color: var(--tblr-secondary);
+}
+.af-required-toggle:hover {
+    color: var(--tblr-body-color);
+}
+.af-required-toggle:has(:checked) {
+    color: var(--tblr-danger);
+}
+.af-required-toggle:has(:focus-visible) {
+    outline: 2px solid var(--tblr-primary);
+    outline-offset: 2px;
+    border-radius: var(--tblr-border-radius);
 }
 
 [data-af-table-question]:has(select.is-invalid) td:not(:has(select.is-invalid)) .select2-container--default .select2-selection {

--- a/public/css/advancedforms.css
+++ b/public/css/advancedforms.css
@@ -49,7 +49,7 @@
 [data-af-table-column] .select2-selection--single .select2-selection__rendered::before,
 [data-af-table-question] td .select2-selection--single .select2-selection__rendered::before {
     display: none !important;
-}Ptemp
+}
 
 .af-required-toggle {
     display: inline-flex;

--- a/public/css/advancedforms.css
+++ b/public/css/advancedforms.css
@@ -34,12 +34,6 @@
         display: none !important;
 }
 
-/*
- * GLPI's .select2-selection__rendered has line-height: ~42px + a ::before pseudo-element,
- * making the total height ~80px while the container is ~40px with overflow:hidden.
- * When the selection content is a flex span, it gets pushed below the visible area.
- * Fix applied for both the admin column config panel and the end-user table cells.
- */
 [data-af-table-column] .select2-selection--single .select2-selection__rendered,
 [data-af-table-question] td .select2-selection--single .select2-selection__rendered {
     display: flex !important;
@@ -53,19 +47,6 @@
     display: none !important;
 }
 
-/*
- * Per-cell invalid state for select2 cells.
- *
- * Core (_form-renderer.scss) reddens EVERY select2 of a question as soon as one of
- * its selects is .is-invalid, via a question-level selector:
- *   [data-glpi-form-renderer-question]:has(select.is-invalid) .select2-selection
- * A table holds many selects inside a single question, so one invalid cell would turn
- * every dropdown red. We re-scope the highlight to the offending cell: while the table
- * has an invalid select, valid cells are reset to the default border, and only the cell
- * that actually contains the invalid select keeps the red border.
- *
- * Plain inputs and checkboxes already get their red border from Bootstrap's .is-invalid.
- */
 [data-af-table-question]:has(select.is-invalid) td:not(:has(select.is-invalid)) .select2-container--default .select2-selection {
     border-color: var(--tblr-border-color) !important;
 }

--- a/public/js/modules/AfTableQuestion.js
+++ b/public/js/modules/AfTableQuestion.js
@@ -104,6 +104,11 @@ export class AfTableQuestion {
         // Skip tables hidden by step-by-step navigation or conditional sections.
         if (table.offsetParent === null) { return null; }
 
+        // Core only clears its own server-rendered errors when a new request
+        // round-trips; if we block the submit below, that never happens, leaving
+        // stale messages from a previous attempt next to our fresh ones.
+        table.querySelectorAll('.invalid-tooltip').forEach(el => el.remove());
+
         const requiredCols = (table.dataset.afRequiredCols ?? '')
             .split(',')
             .filter(value => value !== '');
@@ -120,15 +125,22 @@ export class AfTableQuestion {
             if (regex) { patternRegexes[colIndex] = regex; }
         });
 
-        if (requiredCols.length === 0 && Object.keys(patternRegexes).length === 0) { return null; }
-
         let firstInvalid = null;
         table.querySelectorAll('[data-af-table-row]').forEach(row => {
             const controls = AfTableQuestion.#rowControls(row);
-            const rowHasValue = controls.some(control => AfTableQuestion.#hasValue(control));
+            // Browsers reset .value to "" for un-parseable content in type=number
+            // inputs, so hasValue() alone can't see it; badInput must count too.
+            const rowHasValue = controls.some(control => AfTableQuestion.#hasValue(control) || control.validity?.badInput);
 
             controls.forEach(control => {
                 const colIndex = AfTableQuestion.#columnIndex(control);
+
+                if (control.validity?.badInput) {
+                    AfTableQuestion.#setCellError(control, table.dataset.afPatternMsg ?? '');
+                    if (!firstInvalid) { firstInvalid = control; }
+                    return;
+                }
+
                 const hasValue = AfTableQuestion.#hasValue(control);
 
                 if (rowHasValue && requiredCols.includes(colIndex) && !hasValue) {
@@ -139,6 +151,13 @@ export class AfTableQuestion {
 
                 const regex = patternRegexes[colIndex];
                 if (hasValue && regex && !regex.test(control.value)) {
+                    AfTableQuestion.#setCellError(control, table.dataset.afPatternMsg ?? '');
+                    if (!firstInvalid) { firstInvalid = control; }
+                    return;
+                }
+
+                // Native constraint from the column's type (number, email...); "missing" is handled above.
+                if (hasValue && control.validity && !control.validity.valid && !control.validity.valueMissing) {
                     AfTableQuestion.#setCellError(control, table.dataset.afPatternMsg ?? '');
                     if (!firstInvalid) { firstInvalid = control; }
                     return;

--- a/public/js/modules/AfTableQuestion.js
+++ b/public/js/modules/AfTableQuestion.js
@@ -62,8 +62,7 @@ export class AfTableQuestion {
         const clear = e => AfTableQuestion.#clearCellError(e.target);
         this.#body.addEventListener('input', clear);
         if (window.$) {
-            // select2 fires its "change" through jQuery, which native
-            // addEventListener('change') handlers never receive.
+            // select2's "change" only fires through jQuery, not native addEventListener.
             window.$(this.#body).on('change', clear);
         } else {
             this.#body.addEventListener('change', clear);
@@ -108,7 +107,20 @@ export class AfTableQuestion {
         const requiredCols = (table.dataset.afRequiredCols ?? '')
             .split(',')
             .filter(value => value !== '');
-        if (requiredCols.length === 0) { return null; }
+
+        let patternCols = {};
+        try {
+            patternCols = JSON.parse(table.dataset.afPatternCols ?? '{}');
+        } catch {
+            patternCols = {};
+        }
+        const patternRegexes = {};
+        Object.entries(patternCols).forEach(([colIndex, pattern]) => {
+            const regex = AfTableQuestion.#toRegExp(pattern);
+            if (regex) { patternRegexes[colIndex] = regex; }
+        });
+
+        if (requiredCols.length === 0 && Object.keys(patternRegexes).length === 0) { return null; }
 
         let firstInvalid = null;
         table.querySelectorAll('[data-af-table-row]').forEach(row => {
@@ -117,16 +129,46 @@ export class AfTableQuestion {
 
             controls.forEach(control => {
                 const colIndex = AfTableQuestion.#columnIndex(control);
-                const invalid = rowHasValue
-                    && requiredCols.includes(colIndex)
-                    && !AfTableQuestion.#hasValue(control);
-                control.classList.toggle('is-invalid', invalid);
-                if (invalid && !firstInvalid) { firstInvalid = control; }
+                const hasValue = AfTableQuestion.#hasValue(control);
+
+                if (rowHasValue && requiredCols.includes(colIndex) && !hasValue) {
+                    AfTableQuestion.#setCellError(control, table.dataset.afRequiredMsg ?? '');
+                    if (!firstInvalid) { firstInvalid = control; }
+                    return;
+                }
+
+                const regex = patternRegexes[colIndex];
+                if (hasValue && regex && !regex.test(control.value)) {
+                    AfTableQuestion.#setCellError(control, table.dataset.afPatternMsg ?? '');
+                    if (!firstInvalid) { firstInvalid = control; }
+                    return;
+                }
+
+                AfTableQuestion.#clearCellError(control);
             });
         });
 
-        AfTableQuestion.#toggleTableError(table, firstInvalid !== null);
         return firstInvalid;
+    }
+
+    /**
+     * Parses a PHP-style `/regex/flags` string into a RegExp, or a bare pattern
+     * with no delimiters. Only JS-supported flags (gimsuy) are kept.
+     *
+     * @returns {RegExp|null} null if the pattern is empty or invalid.
+     */
+    static #toRegExp(pattern) {
+        if (typeof pattern !== 'string' || pattern === '') { return null; }
+
+        const match = /^\/(.*)\/([a-z]*)$/s.exec(pattern);
+        const body  = match ? match[1] : pattern;
+        const flags = (match ? match[2] : '').split('').filter(f => 'gimsuy'.includes(f)).join('');
+
+        try {
+            return new RegExp(body, flags);
+        } catch {
+            return null;
+        }
     }
 
     /** @returns {Element[]} */
@@ -149,29 +191,26 @@ export class AfTableQuestion {
         return match ? match[1] : '';
     }
 
+    static #setCellError(control, message) {
+        control.classList.add('is-invalid');
+
+        const td = control.closest('td') ?? control.parentElement;
+        if (!td) { return; }
+
+        let feedback = td.querySelector('[data-af-cell-error]');
+        if (!feedback) {
+            feedback = document.createElement('div');
+            feedback.setAttribute('data-af-cell-error', '');
+            feedback.className = 'invalid-feedback d-block';
+            td.appendChild(feedback);
+        }
+        feedback.textContent = message;
+    }
+
     static #clearCellError(control) {
         if (!control?.classList?.contains('is-invalid')) { return; }
         control.classList.remove('is-invalid');
-
-        const table = control.closest('[data-af-table-question]');
-        if (table && !table.querySelector('.is-invalid')) {
-            AfTableQuestion.#toggleTableError(table, false);
-        }
-    }
-
-    static #toggleTableError(table, show) {
-        let message = table.querySelector('[data-af-table-error]');
-        if (!show) {
-            message?.remove();
-            return;
-        }
-        if (!message) {
-            message = document.createElement('div');
-            message.setAttribute('data-af-table-error', '');
-            message.className = 'invalid-feedback d-block';
-            message.textContent = table.dataset.afRequiredMsg ?? '';
-            table.appendChild(message);
-        }
+        control.closest('td')?.querySelector('[data-af-cell-error]')?.remove();
     }
 
     addRow() {

--- a/public/js/modules/AfTableQuestion.js
+++ b/public/js/modules/AfTableQuestion.js
@@ -1,0 +1,245 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+export class AfTableQuestion {
+    static #submitGuardRegistered = false;
+
+    #table;
+    #body;
+    #template;
+    #addBtn;
+    #minRows;
+    #maxRows;
+
+    constructor(tableElement) {
+        this.#table    = tableElement;
+        this.#body     = tableElement.querySelector('[data-af-table-body]');
+        this.#template = tableElement.querySelector('[data-af-table-row-template]');
+        this.#addBtn   = tableElement.querySelector('[data-af-table-add-row]');
+        this.#minRows  = parseInt(tableElement.dataset.afMinRows, 10) || 1;
+        this.#maxRows  = parseInt(tableElement.dataset.afMaxRows, 10) || 50;
+
+        if (!this.#body || !this.#template || !this.#addBtn) {
+            return;
+        }
+
+        this.#addBtn.addEventListener('click', () => this.addRow());
+        this.#body.addEventListener('click', e => {
+            const btn = e.target.closest('[data-af-table-remove-row]');
+            if (btn) {
+                this.removeRow(btn.closest('[data-af-table-row]'));
+            }
+        });
+        // Clear a cell's error state as soon as the user fills it.
+        const clear = e => AfTableQuestion.#clearCellError(e.target);
+        this.#body.addEventListener('input', clear);
+        if (window.$) {
+            // select2 fires its "change" through jQuery, which native
+            // addEventListener('change') handlers never receive.
+            window.$(this.#body).on('change', clear);
+        } else {
+            this.#body.addEventListener('change', clear);
+        }
+        this.#updateButtonStates();
+
+        AfTableQuestion.#registerSubmitGuard();
+    }
+
+    static #registerSubmitGuard() {
+        if (AfTableQuestion.#submitGuardRegistered) { return; }
+        AfTableQuestion.#submitGuardRegistered = true;
+
+        document.addEventListener('click', e => {
+            const trigger = e.target.closest('[data-glpi-form-renderer-action=submit]');
+            if (!trigger) { return; }
+
+            const scope = trigger.closest('form') ?? document;
+            let firstInvalid = null;
+            scope.querySelectorAll('[data-af-table-question]').forEach(table => {
+                const invalid = AfTableQuestion.#validateTable(table);
+                if (invalid && !firstInvalid) { firstInvalid = invalid; }
+            });
+
+            if (firstInvalid) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                // Scroll to the cell, as a select2-managed <select> is itself hidden.
+                (firstInvalid.closest('td') ?? firstInvalid)
+                    .scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+        }, true);
+    }
+
+    /**
+     * @returns {Element|null} the first invalid control of the table, or null.
+     */
+    static #validateTable(table) {
+        // Skip tables hidden by step-by-step navigation or conditional sections.
+        if (table.offsetParent === null) { return null; }
+
+        const requiredCols = (table.dataset.afRequiredCols ?? '')
+            .split(',')
+            .filter(value => value !== '');
+        if (requiredCols.length === 0) { return null; }
+
+        let firstInvalid = null;
+        table.querySelectorAll('[data-af-table-row]').forEach(row => {
+            const controls = AfTableQuestion.#rowControls(row);
+            const rowHasValue = controls.some(control => AfTableQuestion.#hasValue(control));
+
+            controls.forEach(control => {
+                const colIndex = AfTableQuestion.#columnIndex(control);
+                const invalid = rowHasValue
+                    && requiredCols.includes(colIndex)
+                    && !AfTableQuestion.#hasValue(control);
+                control.classList.toggle('is-invalid', invalid);
+                if (invalid && !firstInvalid) { firstInvalid = control; }
+            });
+        });
+
+        AfTableQuestion.#toggleTableError(table, firstInvalid !== null);
+        return firstInvalid;
+    }
+
+    /** @returns {Element[]} */
+    static #rowControls(row) {
+        return Array.from(row.querySelectorAll(
+            'input[name]:not([type=hidden]):not(.select2-search__field), select[name]',
+        ));
+    }
+
+    static #hasValue(control) {
+        if (control.type === 'checkbox' || control.type === 'radio') {
+            return control.checked;
+        }
+        return (control.value ?? '').trim() !== '';
+    }
+
+    /** Extracts the "col_N" index from a cell control name, as a string. */
+    static #columnIndex(control) {
+        const match = /\[col_(\d+)\]/.exec(control.name ?? '');
+        return match ? match[1] : '';
+    }
+
+    static #clearCellError(control) {
+        if (!control?.classList?.contains('is-invalid')) { return; }
+        control.classList.remove('is-invalid');
+
+        const table = control.closest('[data-af-table-question]');
+        if (table && !table.querySelector('.is-invalid')) {
+            AfTableQuestion.#toggleTableError(table, false);
+        }
+    }
+
+    static #toggleTableError(table, show) {
+        let message = table.querySelector('[data-af-table-error]');
+        if (!show) {
+            message?.remove();
+            return;
+        }
+        if (!message) {
+            message = document.createElement('div');
+            message.setAttribute('data-af-table-error', '');
+            message.className = 'invalid-feedback d-block';
+            message.textContent = table.dataset.afRequiredMsg ?? '';
+            table.appendChild(message);
+        }
+    }
+
+    addRow() {
+        const rowCount = this.#rowCount();
+        if (rowCount >= this.#maxRows) {
+            return;
+        }
+        const clone = this.#template.content.cloneNode(true);
+        clone.querySelectorAll('[name]').forEach(el => {
+            el.name = el.name.replace('__ROW__', rowCount);
+        });
+        this.#body.appendChild(clone);
+        this.#initSelectsInRow(this.#body.lastElementChild);
+        this.#updateButtonStates();
+    }
+
+    #initSelectsInRow(row) {
+        if (!row || !window.setupAdaptDropdown) { return; }
+        const limit = parseInt(this.#table.dataset.afS2Limit, 10) || 100;
+        row.querySelectorAll('[data-af-needs-s2]').forEach(select => {
+            const id = 'dropdown_af_eu_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7);
+            select.id = id;
+            const config = {
+                type: 'adapt',
+                field_id: id,
+                width: '100%',
+                dropdown_css_class: '',
+                placeholder: '',
+                ajax_limit_count: limit,
+            };
+            window.select2_configs = window.select2_configs || {};
+            window.select2_configs[id] = config;
+            window.setupAdaptDropdown(config);
+        });
+    }
+
+    removeRow(rowElement) {
+        if (!rowElement || this.#rowCount() <= this.#minRows) {
+            return;
+        }
+        rowElement.remove();
+        this.#reindexRows();
+        this.#updateButtonStates();
+    }
+
+    #reindexRows() {
+        this.#body.querySelectorAll('[data-af-table-row]').forEach((row, i) => {
+            row.querySelectorAll('[name]').forEach(el => {
+                el.name = el.name.replace(/\[\d+\]/, `[${i}]`);
+            });
+        });
+    }
+
+    #updateButtonStates() {
+        const count = this.#rowCount();
+        const atMax = count >= this.#maxRows;
+        const atMin = count <= this.#minRows;
+
+        this.#addBtn.classList.toggle('opacity-25', atMax);
+        this.#addBtn.classList.toggle('pe-none',    atMax);
+
+        this.#body.querySelectorAll('[data-af-table-remove-row]').forEach(icon => {
+            icon.classList.toggle('opacity-25', atMin);
+            icon.classList.toggle('pe-none',    atMin);
+        });
+    }
+
+    #rowCount() {
+        return this.#body.querySelectorAll('[data-af-table-row]').length;
+    }
+}

--- a/public/js/modules/AfTableQuestionConfig.js
+++ b/public/js/modules/AfTableQuestionConfig.js
@@ -127,7 +127,12 @@ export class AfTableQuestionConfig {
             });
         };
 
-        typeSelect.addEventListener('change', update);
+        // select2's "change" only fires through jQuery, not native addEventListener.
+        if (window.$) {
+            window.$(typeSelect).on('change', update);
+        } else {
+            typeSelect.addEventListener('change', update);
+        }
         update();
     }
 
@@ -153,7 +158,11 @@ export class AfTableQuestionConfig {
             }
         };
 
-        typeSelect.addEventListener('change', update);
+        if (window.$) {
+            window.$(typeSelect).on('change', update);
+        } else {
+            typeSelect.addEventListener('change', update);
+        }
         update();
     }
 

--- a/public/js/modules/AfTableQuestionConfig.js
+++ b/public/js/modules/AfTableQuestionConfig.js
@@ -1,0 +1,171 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+export class AfTableQuestionConfig {
+    static #delegationRegistered = false;
+
+    constructor() {
+        AfTableQuestionConfig.#register();
+    }
+
+    static #register() {
+        if (AfTableQuestionConfig.#delegationRegistered) { return; }
+        AfTableQuestionConfig.#delegationRegistered = true;
+
+        document.addEventListener('shown.bs.dropdown', (e) => {
+            const dropdown = e.target.closest('.dropdown');
+            if (!dropdown) { return; }
+            const container = dropdown.querySelector('[data-af-table-columns-container]');
+            if (!container || container.dataset.afTableInited) { return; }
+            container.dataset.afTableInited = '1';
+
+            const cardBody = container.closest('.card-body');
+            if (!cardBody) { return; }
+            const template = cardBody.querySelector('[data-af-table-column-template]');
+            const addBtn = cardBody.querySelector('[data-af-table-column-add]');
+
+            AfTableQuestionConfig.#bindRemoveButtons(container);
+
+            // Bind itemtype visibility for all existing columns
+            container.querySelectorAll('[data-af-table-column]').forEach(row => {
+                AfTableQuestionConfig.#bindItemtypeVisibility(row);
+            });
+
+            if (addBtn && template) {
+                addBtn.addEventListener('click', () => {
+                    AfTableQuestionConfig.#addColumn(container, template);
+                });
+            }
+        });
+    }
+
+    static #addColumn(container, template) {
+        if (!container || !template) { return; }
+        const index = container.querySelectorAll('[data-af-table-column]').length;
+        const clone = template.content.cloneNode(true);
+        clone.querySelectorAll('[name]').forEach(el => {
+            el.name = el.name.replace('__INDEX__', index);
+        });
+        container.appendChild(clone);
+        const newRow = container.lastElementChild;
+        AfTableQuestionConfig.#bindRemoveButtons(newRow);
+        AfTableQuestionConfig.#reindex(container);
+
+        const newSelect = newRow.querySelector('[data-af-table-type-select]');
+        AfTableQuestionConfig.#initNewColumnSelect(newSelect, container.dataset.afTableColumnsContainer);
+        AfTableQuestionConfig.#bindItemtypeVisibility(newRow);
+    }
+
+    static #initNewColumnSelect(select, rand) {
+        if (!select || !rand || !window.setupAdaptDropdown) { return; }
+        const templateConfig = window.select2_configs?.['af-table-type-template-' + rand];
+        if (!templateConfig) { return; }
+        const newId = 'dropdown_af_table_type_' + rand + '_' + Date.now();
+        select.id = newId;
+        const config = { ...templateConfig, field_id: newId };
+        window.select2_configs[newId] = config;
+        window.setupAdaptDropdown(config);
+    }
+
+    static #bindItemtypeVisibility(columnRow) {
+        const typeSelect = columnRow.querySelector('select[name*="[question_type]"]');
+        if (!typeSelect) { return; }
+
+        const container = columnRow.closest('[data-af-table-columns-container]');
+        const rand = container?.dataset.afTableColumnsContainer;
+
+        const update = () => {
+            const selected = typeSelect.value;
+            columnRow.querySelectorAll('[data-af-itemtype-wrapper]').forEach(wrapper => {
+                const show = wrapper.dataset.afItemtypeWrapper === selected;
+                wrapper.style.display = show ? '' : 'none';
+                const sel = wrapper.querySelector('select');
+                if (!sel) { return; }
+                sel.disabled = !show;
+                if (!show) {
+                    // Clear value without triggering Select2 events to keep state clean
+                    sel.value = '';
+                    if (sel.dataset.afS2Inited && window.$) {
+                        window.$(sel).val('').trigger('change.select2');
+                    }
+                    return;
+                }
+                if (!sel.dataset.afS2Inited) {
+                    sel.dataset.afS2Inited = '1';
+                    AfTableQuestionConfig.#initItemtypeSelect(sel, rand);
+                }
+            });
+        };
+
+        typeSelect.addEventListener('change', update);
+        update();
+    }
+
+    static #initItemtypeSelect(select, rand) {
+        if (!select || !window.setupAdaptDropdown) { return; }
+        if (!select.id) {
+            select.id = 'dropdown_af_itemtype_' + Date.now();
+        }
+        const templateConfig = window.select2_configs?.['af-table-type-template-' + rand];
+        const config = {
+            type: 'adapt',
+            field_id: select.id,
+            width: '170px',
+            dropdown_css_class: '',
+            placeholder: select.querySelector('option[value=""]')?.textContent?.trim() ?? '',
+            ajax_limit_count: templateConfig?.ajax_limit_count ?? 100,
+        };
+        window.select2_configs = window.select2_configs || {};
+        window.select2_configs[select.id] = config;
+        window.setupAdaptDropdown(config);
+    }
+
+    static #bindRemoveButtons(scope) {
+        if (!scope) { return; }
+        scope.querySelectorAll('[data-af-table-column-remove]').forEach(btn => {
+            if (btn.dataset.afRemoveBound) { return; }
+            btn.dataset.afRemoveBound = '1';
+            btn.addEventListener('click', () => {
+                const container = btn.closest('[data-af-table-columns-container]');
+                btn.closest('[data-af-table-column]')?.remove();
+                if (container) { AfTableQuestionConfig.#reindex(container); }
+            });
+        });
+    }
+
+    static #reindex(container) {
+        container.querySelectorAll('[data-af-table-column]').forEach((row, i) => {
+            row.querySelectorAll('[name]').forEach(el => {
+                el.name = el.name.replace(/\[columns\]\[\d+\]/, `[columns][${i}]`);
+            });
+        });
+    }
+}

--- a/public/js/modules/AfTableQuestionConfig.js
+++ b/public/js/modules/AfTableQuestionConfig.js
@@ -54,9 +54,10 @@ export class AfTableQuestionConfig {
 
             AfTableQuestionConfig.#bindRemoveButtons(container);
 
-            // Bind itemtype visibility for all existing columns
+            // Bind itemtype and pattern visibility for all existing columns
             container.querySelectorAll('[data-af-table-column]').forEach(row => {
                 AfTableQuestionConfig.#bindItemtypeVisibility(row);
+                AfTableQuestionConfig.#bindPatternVisibility(row);
             });
 
             if (addBtn && template) {
@@ -82,6 +83,7 @@ export class AfTableQuestionConfig {
         const newSelect = newRow.querySelector('[data-af-table-type-select]');
         AfTableQuestionConfig.#initNewColumnSelect(newSelect, container.dataset.afTableColumnsContainer);
         AfTableQuestionConfig.#bindItemtypeVisibility(newRow);
+        AfTableQuestionConfig.#bindPatternVisibility(newRow);
     }
 
     static #initNewColumnSelect(select, rand) {
@@ -123,6 +125,32 @@ export class AfTableQuestionConfig {
                     AfTableQuestionConfig.#initItemtypeSelect(sel, rand);
                 }
             });
+        };
+
+        typeSelect.addEventListener('change', update);
+        update();
+    }
+
+    static #bindPatternVisibility(columnRow) {
+        const typeSelect = columnRow.querySelector('select[name*="[question_type]"]');
+        const patternWrapper = columnRow.querySelector('[data-af-pattern-wrapper]');
+        if (!typeSelect || !patternWrapper) { return; }
+
+        const container = columnRow.closest('[data-af-table-columns-container]');
+        let shortAnswerFqcns = [];
+        try {
+            shortAnswerFqcns = JSON.parse(container?.dataset.afShortAnswerFqcns ?? '[]');
+        } catch {
+            shortAnswerFqcns = [];
+        }
+
+        const update = () => {
+            const show = shortAnswerFqcns.includes(typeSelect.value);
+            patternWrapper.style.display = show ? '' : 'none';
+            if (!show) {
+                const input = patternWrapper.querySelector('input');
+                if (input) { input.value = ''; }
+            }
         };
 
         typeSelect.addEventListener('change', update);

--- a/public/js/modules/AfTableQuestionConfig.js
+++ b/public/js/modules/AfTableQuestionConfig.js
@@ -88,7 +88,7 @@ export class AfTableQuestionConfig {
         if (!select || !rand || !window.setupAdaptDropdown) { return; }
         const templateConfig = window.select2_configs?.['af-table-type-template-' + rand];
         if (!templateConfig) { return; }
-        const newId = 'dropdown_af_table_type_' + rand + '_' + Date.now();
+        const newId = 'dropdown_af_table_type_' + rand + '_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7);
         select.id = newId;
         const config = { ...templateConfig, field_id: newId };
         window.select2_configs[newId] = config;
@@ -132,7 +132,7 @@ export class AfTableQuestionConfig {
     static #initItemtypeSelect(select, rand) {
         if (!select || !window.setupAdaptDropdown) { return; }
         if (!select.id) {
-            select.id = 'dropdown_af_itemtype_' + Date.now();
+            select.id = 'dropdown_af_itemtype_' + Date.now() + '_' + Math.random().toString(36).slice(2, 7);
         }
         const templateConfig = window.select2_configs?.['af-table-type-template-' + rand];
         const config = {

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -40,6 +40,7 @@ use Glpi\Form\QuestionType\QuestionTypeDropdown;
 use Glpi\Form\QuestionType\QuestionTypeUrgency;
 use CommonItilObject_Item;
 use Dropdown;
+use GLPIMailer;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionType;
@@ -218,8 +219,14 @@ final class TableQuestion extends AbstractQuestionType implements
             return $result;
         }
 
+        $type_instances = [];
+        foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
+            $type_instances[$type::class] = $type;
+        }
+
         $required_columns = [];
         $pattern_columns  = [];
+        $native_columns   = [];
         foreach ($this->loadConfig($question)->getColumns() as $index => $col) {
             if ($col[TableQuestionConfig::COL_REQUIRED]) {
                 $required_columns[$index] = $col[TableQuestionConfig::COL_NAME];
@@ -229,10 +236,22 @@ final class TableQuestion extends AbstractQuestionType implements
             $fqcn    = $col[TableQuestionConfig::COL_QUESTION_TYPE];
             if ($pattern !== '' && is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true)) {
                 $pattern_columns[$index] = [$col[TableQuestionConfig::COL_NAME], $pattern];
+                continue;
+            }
+
+            // Text columns rely on the (optional) pattern above; Email/Number
+            // enforce their own native format server-side, since core does not
+            // expose them as a portable regex.
+            $native_type = $type_instances[$fqcn] ?? null;
+            if ($native_type instanceof AbstractQuestionTypeShortAnswer) {
+                $input_type = $native_type->getInputType();
+                if ($input_type === 'email' || $input_type === 'number') {
+                    $native_columns[$index] = [$col[TableQuestionConfig::COL_NAME], $input_type];
+                }
             }
         }
 
-        if ($required_columns === [] && $pattern_columns === []) {
+        if ($required_columns === [] && $pattern_columns === [] && $native_columns === []) {
             return $result;
         }
 
@@ -273,6 +292,25 @@ final class TableQuestion extends AbstractQuestionType implements
                 }
 
                 if (!$matches_pattern) {
+                    $result->addError($question, sprintf(
+                        __('Row %1$s: the column "%2$s" does not match the expected format.', 'advancedforms'),
+                        $row_number,
+                        $name,
+                    ));
+                }
+            }
+
+            foreach ($native_columns as $index => [$name, $input_type]) {
+                $value = $row['col_' . $index] ?? '';
+                if (!is_scalar($value) || (string) $value === '') {
+                    continue;
+                }
+
+                $is_valid = $input_type === 'email'
+                    ? GLPIMailer::validateAddress((string) $value)
+                    : is_numeric($value);
+
+                if (!$is_valid) {
                     $result->addError($question, sprintf(
                         __('Row %1$s: the column "%2$s" does not match the expected format.', 'advancedforms'),
                         $row_number,
@@ -647,10 +685,18 @@ final class TableQuestion extends AbstractQuestionType implements
 
         // FQCN => icon class, consumed by the select2 formatter defined in the template.
         $icons = [];
+        // Only plain-text columns accept a manual pattern; typed short answers
+        // (E-mail, Number, ...) already enforce their own native format.
+        $short_answer_fqcns = [];
         foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
             $fqcn = $type::class;
-            if (isset($compatible_types[$fqcn])) {
-                $icons[$fqcn] = $type->getIcon();
+            if (!isset($compatible_types[$fqcn])) {
+                continue;
+            }
+
+            $icons[$fqcn] = $type->getIcon();
+            if ($type instanceof AbstractQuestionTypeShortAnswer && $type->getInputType() === 'text') {
+                $short_answer_fqcns[] = $fqcn;
             }
         }
 
@@ -662,12 +708,6 @@ final class TableQuestion extends AbstractQuestionType implements
                 (new QuestionTypeItemDropdown())->getAllowedItemtypes(),
             ),
         ];
-
-        // Only short-answer column types (Text, E-mail, Number, ...) accept a validation pattern.
-        $short_answer_fqcns = array_values(array_filter(
-            array_keys($compatible_types),
-            static fn(string $fqcn): bool => is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true),
-        ));
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
@@ -801,7 +841,7 @@ final class TableQuestion extends AbstractQuestionType implements
      * Returns how a table cell should be rendered for the given question type FQCN.
      *
      * @param ?QuestionTypeInterface $type Pre-resolved instance; instantiated from $fqcn when null.
-     * @return array{mode: string, input_type?: string, options?: array<string, string>}
+     * @return array{mode: string, input_type?: string, attributes?: array<string, mixed>, options?: array<string, string>}
      */
     public function getCellInfo(string $fqcn, ?QuestionTypeInterface $type = null): array
     {
@@ -822,11 +862,17 @@ final class TableQuestion extends AbstractQuestionType implements
             return ['mode' => 'checkbox'];
         }
 
-        if (is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true)) {
-            $input_type = $type instanceof AbstractQuestionTypeShortAnswer
-                ? $type->getInputType()
-                : 'text';
-            return ['mode' => 'input', 'input_type' => $input_type];
+        if ($type instanceof AbstractQuestionTypeShortAnswer) {
+            $attributes = [];
+            foreach ($type->getInputAttributes() as $key => $value) {
+                $attributes[(string) $key] = $value;
+            }
+
+            return [
+                'mode'       => 'input',
+                'input_type' => $type->getInputType(),
+                'attributes' => $attributes,
+            ];
         }
 
         return ['mode' => 'input', 'input_type' => 'text'];

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -53,6 +53,8 @@ use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Form\QuestionType\QuestionTypeRequestType;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\Condition\ConditionHandler\EmptyConditionHandler;
+use Glpi\Form\Condition\ConditionHandler\VisibilityConditionHandler;
 use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\QuestionType\QuestionTypeValidationInterface;
 use Glpi\Form\QuestionType\RawAnswerIsHtmlInterface;
@@ -61,11 +63,13 @@ use Glpi\DBAL\JsonFieldInterface;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
 use Override;
+use Safe\Exceptions\PcreException;
 use Session;
 use User;
 
 use function Safe\json_decode;
 use function Safe\json_encode;
+use function Safe\preg_match;
 
 final class TableQuestion extends AbstractQuestionType implements
     ConfigurableItemInterface,
@@ -127,6 +131,24 @@ final class TableQuestion extends AbstractQuestionType implements
             if (!is_string($fqcn) || !$manager->isValidQuestionType($fqcn)) {
                 return false;
             }
+
+            $pattern = $col[TableQuestionConfig::COL_PATTERN] ?? '';
+            if (!is_string($pattern)) {
+                return false;
+            }
+
+            if ($pattern !== '') {
+                // Only `/…/flags`: matches the JS and HTML `pattern` attribute delimiter stripping.
+                if (preg_match('/^\/.*\/[a-zA-Z]*$/s', $pattern) !== 1) {
+                    return false;
+                }
+
+                try {
+                    @preg_match($pattern, ''); // malformed regex logs a PHP warning, silence it
+                } catch (PcreException) {
+                    return false;
+                }
+            }
         }
 
         $min_raw = $input[TableQuestionConfig::MIN_ROWS] ?? 1;
@@ -146,11 +168,13 @@ final class TableQuestion extends AbstractQuestionType implements
                 $name     = $col[TableQuestionConfig::COL_NAME] ?? '';
                 $type     = $col[TableQuestionConfig::COL_QUESTION_TYPE] ?? '';
                 $itemtype = $col[TableQuestionConfig::COL_ITEMTYPE] ?? '';
+                $pattern  = $col[TableQuestionConfig::COL_PATTERN] ?? '';
                 return [
                     TableQuestionConfig::COL_NAME          => is_scalar($name) ? (string) $name : '',
                     TableQuestionConfig::COL_QUESTION_TYPE => is_scalar($type) ? (string) $type : '',
                     TableQuestionConfig::COL_REQUIRED      => (bool) ($col[TableQuestionConfig::COL_REQUIRED] ?? false),
                     TableQuestionConfig::COL_ITEMTYPE      => is_scalar($itemtype) ? (string) $itemtype : '',
+                    TableQuestionConfig::COL_PATTERN       => is_scalar($pattern) ? (string) $pattern : '',
                 ];
             },
             array_filter((array) ($input[TableQuestionConfig::COLUMNS] ?? []), is_array(...)),
@@ -175,8 +199,7 @@ final class TableQuestion extends AbstractQuestionType implements
             return [];
         }
 
-        // Drop entirely empty rows so blank rows are not persisted.
-        // Mandatory columns are enforced by validateAnswer() before submission.
+        // Drop empty rows; required columns are enforced by validateAnswer().
         $result = [];
         foreach ($answer as $row) {
             if (is_array($row) && $this->rowHasValue($row)) {
@@ -196,13 +219,20 @@ final class TableQuestion extends AbstractQuestionType implements
         }
 
         $required_columns = [];
+        $pattern_columns  = [];
         foreach ($this->loadConfig($question)->getColumns() as $index => $col) {
             if ($col[TableQuestionConfig::COL_REQUIRED]) {
                 $required_columns[$index] = $col[TableQuestionConfig::COL_NAME];
             }
+
+            $pattern = $col[TableQuestionConfig::COL_PATTERN] ?? '';
+            $fqcn    = $col[TableQuestionConfig::COL_QUESTION_TYPE];
+            if ($pattern !== '' && is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true)) {
+                $pattern_columns[$index] = [$col[TableQuestionConfig::COL_NAME], $pattern];
+            }
         }
 
-        if ($required_columns === []) {
+        if ($required_columns === [] && $pattern_columns === []) {
             return $result;
         }
 
@@ -229,9 +259,51 @@ final class TableQuestion extends AbstractQuestionType implements
                     ));
                 }
             }
+
+            foreach ($pattern_columns as $index => [$name, $pattern]) {
+                $value = $row['col_' . $index] ?? '';
+                if (!is_scalar($value) || (string) $value === '') {
+                    continue;
+                }
+
+                try {
+                    $matches_pattern = preg_match($pattern, (string) $value) === 1;
+                } catch (PcreException) {
+                    continue; // malformed stored pattern: don't block submission on it
+                }
+
+                if (!$matches_pattern) {
+                    $result->addError($question, sprintf(
+                        __('Row %1$s: the column "%2$s" does not match the expected format.', 'advancedforms'),
+                        $row_number,
+                        $name,
+                    ));
+                }
+            }
         }
 
         return $result;
+    }
+
+    #[Override]
+    public function getConditionHandlers(?JsonFieldInterface $question_config): array
+    {
+        // No regex handler here: it targets the whole value, not a column. See validateAnswer().
+        return [
+            new VisibilityConditionHandler(),
+            new EmptyConditionHandler($this, $question_config),
+        ];
+    }
+
+    /**
+     * Strips `/regex/flags` down to `regex` for the HTML `pattern` attribute, which
+     * takes no delimiters or flags. JS and server-side validation apply the real check.
+     */
+    private function stripRegexDelimiters(string $pattern): string
+    {
+        preg_match('/^\/(.*)\/[a-z]*$/s', $pattern, $matches);
+
+        return $matches[1] ?? $pattern;
     }
 
     /**
@@ -354,8 +426,7 @@ final class TableQuestion extends AbstractQuestionType implements
      */
     private function collectColumnValues(array $rows, int $index): array
     {
-        // Collected into a list (not array keys) so numeric values such as "1"
-        // stay strings instead of being coerced to int array keys.
+        // List, not array keys: keeps numeric values like "1" as strings.
         $values = [];
         foreach ($rows as $row) {
             $raw   = $row['col_' . $index] ?? '';
@@ -592,22 +663,31 @@ final class TableQuestion extends AbstractQuestionType implements
             ),
         ];
 
+        // Only short-answer column types (Text, E-mail, Number, ...) accept a validation pattern.
+        $short_answer_fqcns = array_values(array_filter(
+            array_keys($compatible_types),
+            static fn(string $fqcn): bool => is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true),
+        ));
+
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
             '@advancedforms/editor/question_types/table_config.html.twig',
             [
-                'question'          => $question,
-                'config'            => $config,
-                'compatible_types'  => $compatible_types,
-                'icons_json'        => json_encode($icons),
-                'ajax_limit_count'  => $this->ajaxLimitCount(),
-                'COL_NAME'          => TableQuestionConfig::COL_NAME,
-                'COL_QUESTION_TYPE' => TableQuestionConfig::COL_QUESTION_TYPE,
-                'COL_REQUIRED'      => TableQuestionConfig::COL_REQUIRED,
-                'COL_ITEMTYPE'      => TableQuestionConfig::COL_ITEMTYPE,
-                'MIN_ROWS'          => TableQuestionConfig::MIN_ROWS,
-                'MAX_ROWS'          => TableQuestionConfig::MAX_ROWS,
-                'itemtype_options'  => $itemtype_options,
+                'question'                 => $question,
+                'config'                   => $config,
+                'compatible_types'         => $compatible_types,
+                'icons_json'               => json_encode($icons),
+                'ajax_limit_count'         => $this->ajaxLimitCount(),
+                'COL_NAME'                 => TableQuestionConfig::COL_NAME,
+                'COL_QUESTION_TYPE'        => TableQuestionConfig::COL_QUESTION_TYPE,
+                'COL_REQUIRED'             => TableQuestionConfig::COL_REQUIRED,
+                'COL_ITEMTYPE'             => TableQuestionConfig::COL_ITEMTYPE,
+                'COL_PATTERN'              => TableQuestionConfig::COL_PATTERN,
+                'MIN_ROWS'                 => TableQuestionConfig::MIN_ROWS,
+                'MAX_ROWS'                 => TableQuestionConfig::MAX_ROWS,
+                'itemtype_options'         => $itemtype_options,
+                'short_answer_fqcns'       => $short_answer_fqcns,
+                'short_answer_fqcns_json'  => json_encode($short_answer_fqcns),
             ],
         );
     }
@@ -648,6 +728,11 @@ final class TableQuestion extends AbstractQuestionType implements
             } else {
                 $cell_map[$index]  = $this->getCellInfo($fqcn, $type);
             }
+
+            $pattern = $col[TableQuestionConfig::COL_PATTERN] ?? '';
+            if ($pattern !== '' && ($cell_map[$index]['mode'] ?? '') === 'input') {
+                $cell_map[$index]['pattern'] = $this->stripRegexDelimiters($pattern);
+            }
         }
 
         $twig = TemplateRenderer::getInstance();
@@ -681,8 +766,7 @@ final class TableQuestion extends AbstractQuestionType implements
      */
     public function getCompatibleQuestionTypes(): array
     {
-        // is_a() is used (not in_array) so subclasses of an excluded type are rejected too,
-        // even when their parent type stays compatible (QuestionTypeItemDropdown is allowed).
+        // is_a(), not in_array: also rejects subclasses of an excluded type.
         $excluded = [
             QuestionTypeFile::class,
             QuestionTypeDateTime::class,

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -1,0 +1,845 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\QuestionType;
+
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Form\QuestionType\QuestionTypeDateTime;
+use Glpi\Form\QuestionType\QuestionTypeRadio;
+use Glpi\Form\QuestionType\QuestionTypeDropdown;
+use Glpi\Form\QuestionType\QuestionTypeUrgency;
+use CommonItilObject_Item;
+use Dropdown;
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\AbstractQuestionType;
+use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
+use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
+use Glpi\Form\QuestionType\AbstractQuestionTypeShortAnswer;
+use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeUserDevice;
+use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\QuestionType\QuestionTypeValidationInterface;
+use Glpi\Form\QuestionType\RawAnswerIsHtmlInterface;
+use Glpi\Form\ValidationResult;
+use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
+use Override;
+use Session;
+use User;
+
+use function Safe\json_decode;
+use function Safe\json_encode;
+
+final class TableQuestion extends AbstractQuestionType implements
+    ConfigurableItemInterface,
+    QuestionTypeValidationInterface,
+    RawAnswerIsHtmlInterface
+{
+    #[Override]
+    public function getCategory(): QuestionTypeCategoryInterface
+    {
+        return new AdvancedCategory();
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return __('Table', 'advancedforms');
+    }
+
+    #[Override]
+    public function getIcon(): string
+    {
+        return 'ti ti-table';
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 50;
+    }
+
+    #[Override]
+    public function getExtraDataConfigClass(): string
+    {
+        return TableQuestionConfig::class;
+    }
+
+    /** @param array<mixed> $input */
+    #[Override]
+    public function validateExtraDataInput(array $input): bool
+    {
+        $columns = $input[TableQuestionConfig::COLUMNS] ?? [];
+        if (!is_array($columns) || $columns === []) {
+            return false;
+        }
+
+        $manager = QuestionTypesManager::getInstance();
+        foreach ($columns as $col) {
+            if (!is_array($col)) {
+                return false;
+            }
+
+            $name = $col[TableQuestionConfig::COL_NAME] ?? '';
+            if (!is_string($name) || $name === '') {
+                return false;
+            }
+
+            $fqcn = $col[TableQuestionConfig::COL_QUESTION_TYPE] ?? '';
+            if (!is_string($fqcn) || !$manager->isValidQuestionType($fqcn)) {
+                return false;
+            }
+        }
+
+        $min_raw = $input[TableQuestionConfig::MIN_ROWS] ?? 1;
+        $max_raw = $input[TableQuestionConfig::MAX_ROWS] ?? 50;
+        $min = is_numeric($min_raw) ? (int) $min_raw : 1;
+        $max = is_numeric($max_raw) ? (int) $max_raw : 50;
+        return $min >= 1 && $max >= $min;
+    }
+
+    /** @param array<mixed> $input */
+    #[Override]
+    public function prepareExtraData(array $input): array
+    {
+        $columns = array_values(array_map(
+            static function (mixed $col): array {
+                $col      = is_array($col) ? $col : [];
+                $name     = $col[TableQuestionConfig::COL_NAME] ?? '';
+                $type     = $col[TableQuestionConfig::COL_QUESTION_TYPE] ?? '';
+                $itemtype = $col[TableQuestionConfig::COL_ITEMTYPE] ?? '';
+                return [
+                    TableQuestionConfig::COL_NAME          => is_scalar($name) ? (string) $name : '',
+                    TableQuestionConfig::COL_QUESTION_TYPE => is_scalar($type) ? (string) $type : '',
+                    TableQuestionConfig::COL_REQUIRED      => (bool) ($col[TableQuestionConfig::COL_REQUIRED] ?? false),
+                    TableQuestionConfig::COL_ITEMTYPE      => is_scalar($itemtype) ? (string) $itemtype : '',
+                ];
+            },
+            array_filter((array) ($input[TableQuestionConfig::COLUMNS] ?? []), is_array(...)),
+        ));
+
+        $min_raw = $input[TableQuestionConfig::MIN_ROWS] ?? 1;
+        $max_raw = $input[TableQuestionConfig::MAX_ROWS] ?? 50;
+        $min = max(1, is_numeric($min_raw) ? (int) $min_raw : 1);
+        $max = max($min, is_numeric($max_raw) ? (int) $max_raw : 50);
+
+        return [
+            TableQuestionConfig::COLUMNS  => $columns,
+            TableQuestionConfig::MIN_ROWS => $min,
+            TableQuestionConfig::MAX_ROWS => $max,
+        ];
+    }
+
+    #[Override]
+    public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
+    {
+        if (!is_array($answer)) {
+            return [];
+        }
+
+        // Drop entirely empty rows so blank rows are not persisted.
+        // Mandatory columns are enforced by validateAnswer() before submission.
+        $result = [];
+        foreach ($answer as $row) {
+            if (is_array($row) && $this->rowHasValue($row)) {
+                $result[] = $row;
+            }
+        }
+
+        return $result;
+    }
+
+    #[Override]
+    public function validateAnswer(Question $question, mixed $answer): ValidationResult
+    {
+        $result = new ValidationResult();
+        if (!is_array($answer)) {
+            return $result;
+        }
+
+        $required_columns = [];
+        foreach ($this->loadConfig($question)->getColumns() as $index => $col) {
+            if ($col[TableQuestionConfig::COL_REQUIRED]) {
+                $required_columns[$index] = $col[TableQuestionConfig::COL_NAME];
+            }
+        }
+
+        if ($required_columns === []) {
+            return $result;
+        }
+
+        $row_number = 0;
+        foreach ($answer as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $row_number++;
+
+            // Entirely empty rows are dropped on save, so they are not validated.
+            if (!$this->rowHasValue($row)) {
+                continue;
+            }
+
+            foreach ($required_columns as $index => $name) {
+                $value = $row['col_' . $index] ?? '';
+                if (!is_scalar($value) || (string) $value === '') {
+                    $result->addError($question, sprintf(
+                        __('Row %1$s: the column "%2$s" is required.', 'advancedforms'),
+                        $row_number,
+                        $name,
+                    ));
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array<array-key, mixed> $row
+     */
+    private function rowHasValue(array $row): bool
+    {
+        foreach ($row as $value) {
+            if ($value !== '' && $value !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    #[Override]
+    public function formatRawAnswer(mixed $answer, Question $question): string
+    {
+        $rows = $this->normalizeRawAnswerRows($answer);
+        if ($rows === []) {
+            return '';
+        }
+
+        $columns = $this->loadConfig($question)->getColumns();
+        if ($columns === []) {
+            return '';
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('@advancedforms/table_answer.html.twig', [
+            'headers' => array_map(
+                static fn(array $col): string => $col[TableQuestionConfig::COL_NAME],
+                $columns,
+            ),
+            'rows' => $this->buildDisplayRows($rows, $columns),
+        ]);
+    }
+
+    /**
+     * GLPI stores the raw answer via a JSON roundtrip, so it may already be a
+     * decoded array by the time formatRawAnswer() is called, or still a JSON string.
+     *
+     * @return list<array<array-key, mixed>>
+     */
+    private function normalizeRawAnswerRows(mixed $answer): array
+    {
+        if (is_array($answer)) {
+            $rows = $answer;
+        } elseif (is_string($answer) && $answer !== '') {
+            $decoded = json_decode($answer, associative: true);
+            $rows    = is_array($decoded) ? $decoded : [];
+        } else {
+            $rows = [];
+        }
+
+        return array_values(array_filter($rows, is_array(...)));
+    }
+
+    /**
+     * Resolves stored cell values into display labels, batching DB access so each
+     * column triggers at most one query instead of one query per cell.
+     *
+     * @param list<array<array-key, mixed>> $rows
+     * @param array<array{name: string, question_type: string, required: bool, itemtype: string}> $columns
+     * @return list<list<string>>
+     */
+    private function buildDisplayRows(array $rows, array $columns): array
+    {
+        $label_maps = [];
+        foreach ($columns as $index => $col) {
+            $label_maps[$index] = $this->buildColumnLabelMap(
+                $col[TableQuestionConfig::COL_QUESTION_TYPE],
+                $col[TableQuestionConfig::COL_ITEMTYPE] ?? '',
+                $this->collectColumnValues($rows, $index),
+            );
+        }
+
+        $display_rows = [];
+        foreach ($rows as $row) {
+            $cells = [];
+            foreach (array_keys($columns) as $index) {
+                $raw     = $row['col_' . $index] ?? '';
+                $value   = is_scalar($raw) ? (string) $raw : '';
+                $cells[] = $value === '' ? '' : ($label_maps[$index][$value] ?? $value);
+            }
+
+            $display_rows[] = $cells;
+        }
+
+        return $display_rows;
+    }
+
+    /**
+     * @param list<array<array-key, mixed>> $rows
+     * @return list<string> Unique non-empty stored values found in the column.
+     */
+    private function collectColumnValues(array $rows, int $index): array
+    {
+        // Collected into a list (not array keys) so numeric values such as "1"
+        // stay strings instead of being coerced to int array keys.
+        $values = [];
+        foreach ($rows as $row) {
+            $raw   = $row['col_' . $index] ?? '';
+            $value = is_scalar($raw) ? (string) $raw : '';
+            if ($value !== '' && !in_array($value, $values, true)) {
+                $values[] = $value;
+            }
+        }
+
+        return $values;
+    }
+
+    /**
+     * Builds a [stored value => display label] map for a column.
+     * An empty map means the stored value is displayed as-is.
+     *
+     * @param list<string> $values Unique non-empty stored values to resolve.
+     * @return array<array-key, string>
+     */
+    private function buildColumnLabelMap(string $fqcn, string $itemtype, array $values): array
+    {
+        return match (true) {
+            $values === [] => [],
+            is_a($fqcn, AbstractQuestionTypeSelectable::class, true) => in_array('1', $values, true) ? ['1' => __('Yes')] : [],
+            is_a($fqcn, AbstractQuestionTypeActors::class, true)     => $this->resolveUserNames($values),
+            is_a($fqcn, QuestionTypeUserDevice::class, true)         => $this->resolveDeviceNames($values),
+            is_a($fqcn, QuestionTypeItem::class, true)               => $this->resolveItemNames($itemtype, $values),
+            default => [],
+        };
+    }
+
+    /**
+     * @param list<string> $values
+     * @return array<array-key, string>
+     */
+    private function resolveUserNames(array $values): array
+    {
+        $ids = $this->toPositiveIds($values);
+        if ($ids === []) {
+            return [];
+        }
+
+        global $DB;
+
+        $map = [];
+        foreach ($DB->request([
+            'SELECT' => ['id', 'name', 'realname', 'firstname'],
+            'FROM'   => User::getTable(),
+            'WHERE'  => ['id' => $ids],
+        ]) as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $id = is_numeric($row['id']) ? (int) $row['id'] : 0;
+            $map[(string) $id] = formatUserName(
+                $id,
+                is_string($row['name'] ?? null) ? $row['name'] : null,
+                is_string($row['realname'] ?? null) ? $row['realname'] : null,
+                is_string($row['firstname'] ?? null) ? $row['firstname'] : null,
+            );
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param list<string> $values
+     * @return array<array-key, string>
+     */
+    private function resolveItemNames(string $itemtype, array $values): array
+    {
+        if ($itemtype === '' || !class_exists($itemtype)) {
+            return [];
+        }
+
+        $item = getItemForItemtype($itemtype);
+        if ($item === false) {
+            return [];
+        }
+
+        $ids = $this->toPositiveIds($values);
+        if ($ids === []) {
+            return [];
+        }
+
+        global $DB;
+
+        $map = [];
+        foreach ($DB->request([
+            'SELECT' => ['id', 'name'],
+            'FROM'   => $item->getTable(),
+            'WHERE'  => ['id' => $ids],
+        ]) as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $id = is_numeric($row['id']) ? (int) $row['id'] : 0;
+            $map[(string) $id] = is_string($row['name'] ?? null) ? $row['name'] : (string) $id;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param list<string> $values "Itemtype_id" strings as produced by getMyDevices().
+     * @return array<array-key, string>
+     */
+    private function resolveDeviceNames(array $values): array
+    {
+        global $DB;
+
+        // Group ids by device itemtype so each itemtype is queried only once.
+        $ids_by_itemtype = [];
+        foreach ($values as $value) {
+            if (!str_contains($value, '_')) {
+                continue;
+            }
+
+            [$device_itemtype, $device_id] = explode('_', $value, 2);
+            if (!is_numeric($device_id) || !class_exists($device_itemtype)) {
+                continue;
+            }
+
+            $ids_by_itemtype[$device_itemtype][] = (int) $device_id;
+        }
+
+        $map = [];
+        foreach ($ids_by_itemtype as $device_itemtype => $ids) {
+            $item = getItemForItemtype($device_itemtype);
+            if ($item === false) {
+                continue;
+            }
+
+            foreach ($DB->request([
+                'SELECT' => ['id', 'name'],
+                'FROM'   => $item->getTable(),
+                'WHERE'  => ['id' => $ids],
+            ]) as $row) {
+                if (!is_array($row)) {
+                    continue;
+                }
+
+                $id   = is_numeric($row['id']) ? (int) $row['id'] : 0;
+                $name = is_string($row['name'] ?? null) ? $row['name'] : '';
+                if ($name !== '') {
+                    $map[$device_itemtype . '_' . $id] = $name;
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<int> Strictly positive integer ids.
+     */
+    private function toPositiveIds(array $values): array
+    {
+        return array_values(array_filter(
+            array_map(static fn(string $value): int => (int) $value, $values),
+            static fn(int $id): bool => $id > 0,
+        ));
+    }
+
+    #[Override]
+    public static function getConfigKey(): string
+    {
+        return 'enable_question_type_table';
+    }
+
+    #[Override]
+    public function getConfigTitle(): string
+    {
+        return __('Table question type', 'advancedforms');
+    }
+
+    #[Override]
+    public function getConfigDescription(): string
+    {
+        return __('Allow users to fill in tabular data with configurable columns.', 'advancedforms');
+    }
+
+    #[Override]
+    public function getConfigIcon(): string
+    {
+        return $this->getIcon();
+    }
+
+    #[Override]
+    public function renderAdministrationTemplate(Question|null $question): string
+    {
+        $config = ($question instanceof Question)
+            ? $this->loadConfig($question)
+            : new TableQuestionConfig();
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render(
+            '@advancedforms/editor/question_types/table_admin.html.twig',
+            [
+                'question'        => $question,
+                'config'          => $config,
+                'advanced_config' => $this->renderAdvancedConfigurationTemplate($question),
+            ],
+        );
+    }
+
+    #[Override]
+    public function renderAdvancedConfigurationTemplate(?Question $question): string
+    {
+        $config = ($question instanceof Question)
+            ? $this->loadConfig($question)
+            : new TableQuestionConfig();
+
+        $compatible_types = $this->getCompatibleQuestionTypes();
+
+        // FQCN => icon class, consumed by the select2 formatter defined in the template.
+        $icons = [];
+        foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
+            $fqcn = $type::class;
+            if (isset($compatible_types[$fqcn])) {
+                $icons[$fqcn] = $type->getIcon();
+            }
+        }
+
+        $itemtype_options = [
+            QuestionTypeItem::class => Dropdown::buildItemtypesDropdownOptions(
+                (new QuestionTypeItem())->getAllowedItemtypes(),
+            ),
+            QuestionTypeItemDropdown::class => Dropdown::buildItemtypesDropdownOptions(
+                (new QuestionTypeItemDropdown())->getAllowedItemtypes(),
+            ),
+        ];
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render(
+            '@advancedforms/editor/question_types/table_config.html.twig',
+            [
+                'question'          => $question,
+                'config'            => $config,
+                'compatible_types'  => $compatible_types,
+                'icons_json'        => json_encode($icons),
+                'ajax_limit_count'  => $this->ajaxLimitCount(),
+                'COL_NAME'          => TableQuestionConfig::COL_NAME,
+                'COL_QUESTION_TYPE' => TableQuestionConfig::COL_QUESTION_TYPE,
+                'COL_REQUIRED'      => TableQuestionConfig::COL_REQUIRED,
+                'COL_ITEMTYPE'      => TableQuestionConfig::COL_ITEMTYPE,
+                'MIN_ROWS'          => TableQuestionConfig::MIN_ROWS,
+                'MAX_ROWS'          => TableQuestionConfig::MAX_ROWS,
+                'itemtype_options'  => $itemtype_options,
+            ],
+        );
+    }
+
+    #[Override]
+    public function renderEndUserTemplate(Question $question): string
+    {
+        $config = $this->loadConfig($question);
+
+        $type_instances = [];
+        foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
+            $type_instances[$type::class] = $type;
+        }
+
+        $cell_map           = [];
+        $user_options       = null;
+        $device_options     = null;
+        $glpi_item_options  = []; // keyed by itemtype FQCN to avoid duplicate DB queries
+
+        foreach ($config->getColumns() as $index => $col) {
+            $fqcn     = $col[TableQuestionConfig::COL_QUESTION_TYPE];
+            $type     = $type_instances[$fqcn] ?? null;
+            $itemtype = $col[TableQuestionConfig::COL_ITEMTYPE] ?? '';
+
+            if (is_a($fqcn, AbstractQuestionTypeActors::class, true)) {
+                $user_options     ??= $this->buildUserOptions();
+                $cell_map[$index]  = ['mode' => 'select', 'options' => $user_options];
+            } elseif (is_a($fqcn, QuestionTypeUserDevice::class, true)) {
+                $device_options   ??= $this->buildUserDeviceOptions();
+                $cell_map[$index]  = ['mode' => 'select', 'options' => $device_options];
+            } elseif (is_a($fqcn, QuestionTypeItem::class, true)) {
+                if ($itemtype !== '' && class_exists($itemtype)) {
+                    $glpi_item_options[$itemtype] ??= $this->buildGlpiItemtypeOptions($itemtype);
+                    $cell_map[$index] = ['mode' => 'select', 'options' => $glpi_item_options[$itemtype]];
+                } else {
+                    $cell_map[$index] = ['mode' => 'input', 'input_type' => 'text'];
+                }
+            } else {
+                $cell_map[$index]  = $this->getCellInfo($fqcn, $type);
+            }
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render(
+            '@advancedforms/table_end_user.html.twig',
+            [
+                'question'         => $question,
+                'config'           => $config,
+                'column_cell_map'  => $cell_map,
+                'ajax_limit_count' => $this->ajaxLimitCount(),
+            ],
+        );
+    }
+
+    /**
+     * Resolves the configured select2 AJAX result limit, falling back to 100.
+     */
+    private function ajaxLimitCount(): int
+    {
+        global $CFG_GLPI;
+
+        $value = $CFG_GLPI['ajax_limit_count'] ?? 100;
+        return is_numeric($value) ? (int) $value : 100;
+    }
+
+    /**
+     * Returns question types compatible with a table cell column.
+     * Key = FQCN, Value = display name.
+     *
+     * @return array<string, string>
+     */
+    public function getCompatibleQuestionTypes(): array
+    {
+        // is_a() is used (not in_array) so subclasses of an excluded type are rejected too,
+        // even when their parent type stays compatible (QuestionTypeItemDropdown is allowed).
+        $excluded = [
+            QuestionTypeFile::class,
+            QuestionTypeDateTime::class,
+            QuestionTypeRadio::class,
+            QuestionTypeDropdown::class,
+            QuestionTypeUrgency::class,
+            QuestionTypeRequestType::class,
+            TreeCascadeDropdownQuestion::class,
+            IpAddressQuestion::class,
+            HostnameQuestion::class,
+            HiddenQuestion::class,
+            LdapQuestion::class,
+            self::class,
+        ];
+
+        $types = [];
+        foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
+            $fqcn = $type::class;
+            foreach ($excluded as $excluded_fqcn) {
+                if (is_a($fqcn, $excluded_fqcn, true)) {
+                    continue 2;
+                }
+            }
+
+            $types[$fqcn] = $type->getName();
+        }
+
+        return $types;
+    }
+
+    /**
+     * Returns how a table cell should be rendered for the given question type FQCN.
+     *
+     * @param ?QuestionTypeInterface $type Pre-resolved instance; instantiated from $fqcn when null.
+     * @return array{mode: string, input_type?: string, options?: array<string, string>}
+     */
+    public function getCellInfo(string $fqcn, ?QuestionTypeInterface $type = null): array
+    {
+        if (!$type instanceof QuestionTypeInterface) {
+            foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $instance) {
+                if ($instance::class === $fqcn) {
+                    $type = $instance;
+                    break;
+                }
+            }
+        }
+
+        if ($type?->isHiddenInput()) {
+            return ['mode' => 'input', 'input_type' => 'hidden'];
+        }
+
+        if (is_a($fqcn, AbstractQuestionTypeSelectable::class, true)) {
+            return ['mode' => 'checkbox'];
+        }
+
+        if (is_a($fqcn, AbstractQuestionTypeShortAnswer::class, true)) {
+            $input_type = $type instanceof AbstractQuestionTypeShortAnswer
+                ? $type->getInputType()
+                : 'text';
+            return ['mode' => 'input', 'input_type' => $input_type];
+        }
+
+        return ['mode' => 'input', 'input_type' => 'text'];
+    }
+
+    /**
+     * Builds a [value => label] options array for actor-type columns.
+     * Loads up to 200 active users from the database.
+     *
+     * @return array<int|string, string>
+     */
+    private function buildUserOptions(): array
+    {
+        global $DB;
+
+        $options = ['' => Dropdown::EMPTY_VALUE];
+
+        $rows = $DB->request([
+            'SELECT' => ['id', 'name', 'realname', 'firstname'],
+            'FROM'   => User::getTable(),
+            'WHERE'  => ['is_active' => 1, 'is_deleted' => 0],
+            'ORDER'  => ['realname', 'firstname', 'name'],
+            'LIMIT'  => 200,
+        ]);
+
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $id = is_numeric($row['id']) ? (int) $row['id'] : 0;
+            $options[(string) $id] = formatUserName(
+                $id,
+                is_string($row['name'] ?? null) ? $row['name'] : null,
+                is_string($row['realname'] ?? null) ? $row['realname'] : null,
+                is_string($row['firstname'] ?? null) ? $row['firstname'] : null,
+            );
+        }
+
+        return $options;
+    }
+
+    /**
+     * Builds an optgroup-keyed options array for the User Device column type.
+     * Keys at the top level are group labels; inner keys are "Itemtype_id" strings.
+     *
+     * @return array<string, string|array<string, string>>
+     */
+    private function buildUserDeviceOptions(): array
+    {
+        $devices = CommonItilObject_Item::getMyDevices(
+            intval(Session::getLoginUserID()),
+            Session::getActiveEntities(),
+        );
+
+        return array_merge(['' => Dropdown::EMPTY_VALUE], $devices);
+    }
+
+    /**
+     * Builds a [id => name] options array for a GLPI itemtype (used by Item/ItemDropdown columns).
+     * Applies entity and soft-delete filters when applicable.
+     *
+     * @param class-string $itemtype
+     * @return array<int|string, string>
+     */
+    private function buildGlpiItemtypeOptions(string $itemtype): array
+    {
+        global $DB;
+
+        $options = ['' => Dropdown::EMPTY_VALUE];
+        $item    = getItemForItemtype($itemtype);
+        if ($item === false) {
+            return $options;
+        }
+
+        $where = [];
+
+        if ($item->maybeDeleted()) {
+            $where['is_deleted'] = 0;
+        }
+
+        if ($item->isEntityAssign()) {
+            $where = array_merge($where, getEntitiesRestrictCriteria(
+                $item->getTable(),
+                '',
+                '',
+                $item->maybeRecursive(),
+            ));
+        }
+
+        $criteria = [
+            'SELECT' => ['id', 'name'],
+            'FROM'   => $item->getTable(),
+            'ORDER'  => 'name',
+            'LIMIT'  => 200,
+        ];
+
+        if ($where !== []) {
+            $criteria['WHERE'] = $where;
+        }
+
+        foreach ($DB->request($criteria) as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $options[(string) (is_numeric($row['id']) ? (int) $row['id'] : 0)] = is_string($row['name']) ? $row['name'] : '';
+        }
+
+        return $options;
+    }
+
+    private function loadConfig(Question $question): TableQuestionConfig
+    {
+        $decoded = [];
+        if (is_string($question->fields['extra_data'])) {
+            $raw = json_decode($question->fields['extra_data'], associative: true);
+            if (is_array($raw)) {
+                $decoded = $raw;
+            }
+        }
+
+        $config = $this->getExtraDataConfig($decoded);
+        return $config instanceof TableQuestionConfig ? $config : new TableQuestionConfig();
+    }
+}

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -130,7 +130,7 @@ final class TableQuestion extends AbstractQuestionType implements
         $max_raw = $input[TableQuestionConfig::MAX_ROWS] ?? 50;
         $min = is_numeric($min_raw) ? (int) $min_raw : 1;
         $max = is_numeric($max_raw) ? (int) $max_raw : 50;
-        return $min >= 1 && $max >= $min;
+        return $min >= 1 && $max >= $min && $max <= 50;
     }
 
     /** @param array<mixed> $input */

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -156,7 +156,7 @@ final class TableQuestion extends AbstractQuestionType implements
         $min_raw = $input[TableQuestionConfig::MIN_ROWS] ?? 1;
         $max_raw = $input[TableQuestionConfig::MAX_ROWS] ?? 50;
         $min = max(1, is_numeric($min_raw) ? (int) $min_raw : 1);
-        $max = max($min, is_numeric($max_raw) ? (int) $max_raw : 50);
+        $max = min(50, max($min, is_numeric($max_raw) ? (int) $max_raw : 50));
 
         return [
             TableQuestionConfig::COLUMNS  => $columns,

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -53,9 +53,11 @@ use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Form\QuestionType\QuestionTypeRequestType;
 use Glpi\Form\QuestionType\QuestionTypeUserDevice;
 use Glpi\Form\QuestionType\QuestionTypesManager;
+use Glpi\Form\Condition\ConditionValueTransformerInterface;
 use Glpi\Form\QuestionType\QuestionTypeValidationInterface;
 use Glpi\Form\QuestionType\RawAnswerIsHtmlInterface;
 use Glpi\Form\ValidationResult;
+use Glpi\DBAL\JsonFieldInterface;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
 use Override;
@@ -67,6 +69,7 @@ use function Safe\json_encode;
 
 final class TableQuestion extends AbstractQuestionType implements
     ConfigurableItemInterface,
+    ConditionValueTransformerInterface,
     QuestionTypeValidationInterface,
     RawAnswerIsHtmlInterface
 {
@@ -243,6 +246,29 @@ final class TableQuestion extends AbstractQuestionType implements
         }
 
         return false;
+    }
+
+    #[Override]
+    public function transformConditionValueForComparisons(mixed $value, ?JsonFieldInterface $question_config): string|array
+    {
+        if (!is_array($value)) {
+            return is_scalar($value) ? (string) $value : '';
+        }
+
+        $flat = [];
+        foreach ($value as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            foreach ($row as $cell) {
+                if (is_scalar($cell) && (string) $cell !== '') {
+                    $flat[] = (string) $cell;
+                }
+            }
+        }
+
+        return $flat;
     }
 
     #[Override]

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -140,7 +140,7 @@ final class TableQuestion extends AbstractQuestionType implements
 
             if ($pattern !== '') {
                 // Only `/…/flags`: matches the JS and HTML `pattern` attribute delimiter stripping.
-                if (preg_match('/^\/.*\/[a-zA-Z]*$/s', $pattern) !== 1) {
+                if (preg_match('/^\/.*\/[a-z]*$/s', $pattern) !== 1) {
                     return false;
                 }
 

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -53,8 +53,10 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
 
     public const COL_ITEMTYPE      = 'itemtype';
 
+    public const COL_PATTERN       = 'pattern';
+
     /**
-     * @param array<array{name: string, question_type: string, required: bool, itemtype: string}> $columns
+     * @param array<array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}> $columns
      */
     public function __construct(
         private array $columns  = [],
@@ -64,7 +66,7 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
 
     /**
      * @param array{
-     *   columns?: array<array{name?: string, question_type?: string, required?: bool, itemtype?: string}>,
+     *   columns?: array<array{name?: string, question_type?: string, required?: bool, itemtype?: string, pattern?: string}>,
      *   min_rows?: int,
      *   max_rows?: int
      * } $data
@@ -78,6 +80,7 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
                 self::COL_QUESTION_TYPE => (string) ($col[self::COL_QUESTION_TYPE] ?? ''),
                 self::COL_REQUIRED      => (bool) ($col[self::COL_REQUIRED] ?? false),
                 self::COL_ITEMTYPE      => (string) ($col[self::COL_ITEMTYPE] ?? ''),
+                self::COL_PATTERN       => (string) ($col[self::COL_PATTERN] ?? ''),
             ],
             array_filter($data[self::COLUMNS] ?? [], is_array(...)),
         ));
@@ -94,7 +97,7 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
 
     /**
      * @return array{
-     *   columns: array<array{name: string, question_type: string, required: bool, itemtype: string}>,
+     *   columns: array<array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}>,
      *   min_rows: int,
      *   max_rows: int
      * }
@@ -109,7 +112,7 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
         ];
     }
 
-    /** @return array<array{name: string, question_type: string, required: bool, itemtype: string}> */
+    /** @return array<array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}> */
     public function getColumns(): array
     {
         return $this->columns;

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -82,10 +82,13 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
             array_filter($data[self::COLUMNS] ?? [], is_array(...)),
         ));
 
+        $min_rows = max(1, (int) ($data[self::MIN_ROWS] ?? 1));
+        $max_rows = min(50, max($min_rows, (int) ($data[self::MAX_ROWS] ?? 50)));
+
         return new self(
             columns: $columns,
-            min_rows: max(1, (int) ($data[self::MIN_ROWS] ?? 1)),
-            max_rows: max(1, (int) ($data[self::MAX_ROWS] ?? 50)),
+            min_rows: $min_rows,
+            max_rows: $max_rows,
         );
     }
 

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -82,8 +82,8 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
             array_filter($data[self::COLUMNS] ?? [], is_array(...)),
         ));
 
-        $min_rows = max(1, (int) ($data[self::MIN_ROWS] ?? 1));
-        $max_rows = max($min_rows, (int) ($data[self::MAX_ROWS] ?? 50));
+        $min_rows = min(50, max(1, (int) ($data[self::MIN_ROWS] ?? 1)));
+        $max_rows = min(50, max($min_rows, (int) ($data[self::MAX_ROWS] ?? 50)));
 
         return new self(
             columns: $columns,

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -83,7 +83,7 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
         ));
 
         $min_rows = max(1, (int) ($data[self::MIN_ROWS] ?? 1));
-        $max_rows = min(50, max($min_rows, (int) ($data[self::MAX_ROWS] ?? 50)));
+        $max_rows = max($min_rows, (int) ($data[self::MAX_ROWS] ?? 50));
 
         return new self(
             columns: $columns,

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\QuestionType;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final readonly class TableQuestionConfig implements JsonFieldInterface
+{
+    public const COLUMNS          = 'columns';
+
+    public const MIN_ROWS         = 'min_rows';
+
+    public const MAX_ROWS         = 'max_rows';
+
+    // Column sub-keys
+    public const COL_NAME          = 'name';
+
+    public const COL_QUESTION_TYPE = 'question_type';
+
+    public const COL_REQUIRED      = 'required';
+
+    public const COL_ITEMTYPE      = 'itemtype';
+
+    /**
+     * @param array<array{name: string, question_type: string, required: bool, itemtype: string}> $columns
+     */
+    public function __construct(
+        private array $columns  = [],
+        private int   $min_rows = 1,
+        private int   $max_rows = 50,
+    ) {}
+
+    /**
+     * @param array{
+     *   columns?: array<array{name?: string, question_type?: string, required?: bool, itemtype?: string}>,
+     *   min_rows?: int,
+     *   max_rows?: int
+     * } $data
+     */
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $columns = array_values(array_map(
+            fn($col) => [
+                self::COL_NAME          => (string) ($col[self::COL_NAME] ?? ''),
+                self::COL_QUESTION_TYPE => (string) ($col[self::COL_QUESTION_TYPE] ?? ''),
+                self::COL_REQUIRED      => (bool) ($col[self::COL_REQUIRED] ?? false),
+                self::COL_ITEMTYPE      => (string) ($col[self::COL_ITEMTYPE] ?? ''),
+            ],
+            array_filter($data[self::COLUMNS] ?? [], is_array(...)),
+        ));
+
+        return new self(
+            columns: $columns,
+            min_rows: max(1, (int) ($data[self::MIN_ROWS] ?? 1)),
+            max_rows: max(1, (int) ($data[self::MAX_ROWS] ?? 50)),
+        );
+    }
+
+    /**
+     * @return array{
+     *   columns: array<array{name: string, question_type: string, required: bool, itemtype: string}>,
+     *   min_rows: int,
+     *   max_rows: int
+     * }
+     */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::COLUMNS  => $this->columns,
+            self::MIN_ROWS => $this->min_rows,
+            self::MAX_ROWS => $this->max_rows,
+        ];
+    }
+
+    /** @return array<array{name: string, question_type: string, required: bool, itemtype: string}> */
+    public function getColumns(): array
+    {
+        return $this->columns;
+    }
+
+    public function getMinRows(): int
+    {
+        return $this->min_rows;
+    }
+
+    public function getMaxRows(): int
+    {
+        return $this->max_rows;
+    }
+}

--- a/src/Service/ConfigManager.php
+++ b/src/Service/ConfigManager.php
@@ -42,6 +42,7 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\HiddenQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\HostnameQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\IpAddressQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
 
 final class ConfigManager
@@ -66,6 +67,7 @@ final class ConfigManager
             new HiddenQuestion(),
             new LdapQuestion(),
             new TreeCascadeDropdownQuestion(),
+            new TableQuestion(),
         ];
     }
 

--- a/templates/editor/question_types/table_admin.html.twig
+++ b/templates/editor/question_types/table_admin.html.twig
@@ -1,0 +1,65 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% set has_columns = config.getColumns()|length > 0 %}
+
+<div class="w-100">
+    <div class="d-flex justify-content-end mb-1">
+        {{ advanced_config|raw }}
+    </div>
+    {% if has_columns %}
+        <div class="overflow-auto">
+            <table class="table table-bordered table-sm mb-0">
+                <thead>
+                    <tr>
+                        {% for col in config.getColumns() %}
+                            <th class="text-truncate py-1 px-2" style="max-width: 120px; font-size: 0.8rem">
+                                {{ col.name }}
+                                {% if col.required %}<span class="text-danger" aria-hidden="true">*</span>{% endif %}
+                            </th>
+                        {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        {% for col in config.getColumns() %}
+                            <td class="text-muted small py-1 px-2">…</td>
+                        {% endfor %}
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    {% else %}
+        <div class="form-control text-muted fst-italic">
+            {{ __("Define columns below", "advancedforms") }}
+        </div>
+    {% endif %}
+</div>

--- a/templates/editor/question_types/table_admin.html.twig
+++ b/templates/editor/question_types/table_admin.html.twig
@@ -31,7 +31,7 @@
 
 {% set has_columns = config.getColumns()|length > 0 %}
 
-<div class="w-100">
+<div class="w-100" data-af-table-admin>
     <div class="d-flex justify-content-end mb-1">
         {{ advanced_config|raw }}
     </div>

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -239,7 +239,7 @@
                             name="extra_data[{{ MIN_ROWS }}]"
                             value="{{ config.getMinRows() }}"
                             min="1"
-                            max="200"
+                            max="50"
                             step="1"
                         >
                     </label>
@@ -252,7 +252,7 @@
                             name="extra_data[{{ MAX_ROWS }}]"
                             value="{{ config.getMaxRows() }}"
                             min="1"
-                            max="200"
+                            max="50"
                             step="1"
                         >
                     </label>

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -118,15 +118,21 @@
                                     </select>
                                 </div>
                             {% endfor %}
-                            <label class="d-flex align-items-center gap-1 mb-0 text-nowrap">
+                            <label
+                                class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                title="{{ __('Required column', 'advancedforms') }}"
+                            >
                                 <input
                                     type="checkbox"
-                                    class="form-check-input"
+                                    class="visually-hidden"
                                     name="extra_data[columns][{{ index }}][{{ COL_REQUIRED }}]"
                                     value="1"
+                                    aria-label="{{ __('Required column', 'advancedforms') }}"
                                     {{ col[COL_REQUIRED] ? 'checked' : '' }}
                                 >
-                                {{ __('Req.', 'advancedforms') }}
+                                <i class="ti ti-asterisk" aria-hidden="true"></i>
                             </label>
                             <i
                                 role="button"
@@ -184,14 +190,20 @@
                                 </select>
                             </div>
                         {% endfor %}
-                        <label class="d-flex align-items-center gap-1 mb-0 text-nowrap">
+                        <label
+                            class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            title="{{ __('Required column', 'advancedforms') }}"
+                        >
                             <input
                                 type="checkbox"
-                                class="form-check-input"
+                                class="visually-hidden"
                                 name="extra_data[columns][__INDEX__][{{ COL_REQUIRED }}]"
                                 value="1"
+                                aria-label="{{ __('Required column', 'advancedforms') }}"
                             >
-                            {{ __('Req.', 'advancedforms') }}
+                            <i class="ti ti-asterisk" aria-hidden="true"></i>
                         </label>
                         <i
                             role="button"

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -70,37 +70,126 @@
                 <div
                     class="mb-3"
                     data-af-table-columns-container="{{ rand }}"
+                    data-af-short-answer-fqcns="{{ short_answer_fqcns_json|e('html_attr') }}"
                 >
                     {% for index, col in config.getColumns() %}
-                        <div class="d-flex align-items-center gap-2 mb-2" data-af-table-column>
+                        <div class="mb-2" data-af-table-column>
+                            <div class="d-flex align-items-center gap-2">
+                                <input
+                                    class="form-control"
+                                    style="flex: 1 1 auto; min-width: 0; width: auto"
+                                    type="text"
+                                    name="extra_data[columns][{{ index }}][{{ COL_NAME }}]"
+                                    value="{{ col[COL_NAME] }}"
+                                    placeholder="{{ __('Column name', 'advancedforms') }}"
+                                >
+                                {% set col_select %}
+                                    {% do call('Dropdown::showFromArray', [
+                                        'extra_data[columns][' ~ index ~ '][' ~ COL_QUESTION_TYPE ~ ']',
+                                        compatible_types,
+                                        {
+                                            'value'             : col[COL_QUESTION_TYPE],
+                                            'class'             : 'form-select',
+                                            'width'             : '200px',
+                                            'templateResult'    : 'window.afTableColumnTypeTemplate',
+                                            'templateSelection' : 'window.afTableColumnTypeTemplate',
+                                        }
+                                    ]) %}
+                                {% endset %}
+                                {{ col_select|raw }}
+                                {% for type_fqcn, options in itemtype_options %}
+                                    <div data-af-itemtype-wrapper="{{ type_fqcn }}" style="display: none">
+                                        <select
+                                            class="form-select flex-shrink-0"
+                                            style="width: 170px"
+                                            name="extra_data[columns][{{ index }}][{{ COL_ITEMTYPE }}]"
+                                            disabled
+                                        >
+                                            <option value="">{{ __('Select a type', 'advancedforms') }}</option>
+                                            {% for group_or_key, value in options %}
+                                                {% if value is iterable %}
+                                                    <optgroup label="{{ group_or_key }}">
+                                                        {% for item_fqcn, name in value %}
+                                                            <option value="{{ item_fqcn }}" {{ col[COL_ITEMTYPE] == item_fqcn ? 'selected' : '' }}>{{ name }}</option>
+                                                        {% endfor %}
+                                                    </optgroup>
+                                                {% else %}
+                                                    <option value="{{ group_or_key }}" {{ col[COL_ITEMTYPE] == group_or_key ? 'selected' : '' }}>{{ value }}</option>
+                                                {% endif %}
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                {% endfor %}
+                                <label
+                                    class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
+                                    data-bs-toggle="tooltip"
+                                    data-bs-placement="top"
+                                    title="{{ __('Required column', 'advancedforms') }}"
+                                >
+                                    <input
+                                        type="checkbox"
+                                        class="visually-hidden"
+                                        name="extra_data[columns][{{ index }}][{{ COL_REQUIRED }}]"
+                                        value="1"
+                                        aria-label="{{ __('Required column', 'advancedforms') }}"
+                                        {{ col[COL_REQUIRED] ? 'checked' : '' }}
+                                    >
+                                    <i class="ti ti-asterisk" aria-hidden="true"></i>
+                                </label>
+                                <i
+                                    role="button"
+                                    class="ti ti-trash ms-1 cursor-pointer text-danger flex-shrink-0"
+                                    data-bs-toggle="tooltip"
+                                    data-bs-placement="top"
+                                    title="{{ __('Remove column', 'advancedforms') }}"
+                                    aria-label="{{ __('Remove column', 'advancedforms') }}"
+                                    data-af-table-column-remove
+                                ></i>
+                            </div>
+                            <div class="mt-1" data-af-pattern-wrapper style="display: none">
+                                <input
+                                    class="form-control form-control-sm"
+                                    type="text"
+                                    name="extra_data[columns][{{ index }}][{{ COL_PATTERN }}]"
+                                    value="{{ col[COL_PATTERN] }}"
+                                    placeholder="/regex/"
+                                    data-bs-toggle="tooltip"
+                                    data-bs-placement="top"
+                                    title="{{ __('Validation pattern', 'advancedforms') }}"
+                                    aria-label="{{ __('Validation pattern', 'advancedforms') }}"
+                                >
+                            </div>
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# Template cloned by JS for new columns #}
+                <template data-af-table-column-template="{{ rand }}">
+                    <div class="mb-2" data-af-table-column>
+                        <div class="d-flex align-items-center gap-2">
                             <input
                                 class="form-control"
                                 style="flex: 1 1 auto; min-width: 0; width: auto"
                                 type="text"
-                                name="extra_data[columns][{{ index }}][{{ COL_NAME }}]"
-                                value="{{ col[COL_NAME] }}"
+                                name="extra_data[columns][__INDEX__][{{ COL_NAME }}]"
                                 placeholder="{{ __('Column name', 'advancedforms') }}"
                             >
-                            {% set col_select %}
-                                {% do call('Dropdown::showFromArray', [
-                                    'extra_data[columns][' ~ index ~ '][' ~ COL_QUESTION_TYPE ~ ']',
-                                    compatible_types,
-                                    {
-                                        'value'             : col[COL_QUESTION_TYPE],
-                                        'class'             : 'form-select',
-                                        'width'             : '200px',
-                                        'templateResult'    : 'window.afTableColumnTypeTemplate',
-                                        'templateSelection' : 'window.afTableColumnTypeTemplate',
-                                    }
-                                ]) %}
-                            {% endset %}
-                            {{ col_select|raw }}
+                            <select
+                                class="form-select"
+                                style="width: 200px; flex-shrink: 0"
+                                name="extra_data[columns][__INDEX__][{{ COL_QUESTION_TYPE }}]"
+                                data-af-table-type-select
+                            >
+                                {% for fqcn, label in compatible_types %}
+                                    <option value="{{ fqcn }}">{{ label }}</option>
+                                {% endfor %}
+                            </select>
                             {% for type_fqcn, options in itemtype_options %}
                                 <div data-af-itemtype-wrapper="{{ type_fqcn }}" style="display: none">
                                     <select
                                         class="form-select flex-shrink-0"
                                         style="width: 170px"
-                                        name="extra_data[columns][{{ index }}][{{ COL_ITEMTYPE }}]"
+                                        name="extra_data[columns][__INDEX__][{{ COL_ITEMTYPE }}]"
                                         disabled
                                     >
                                         <option value="">{{ __('Select a type', 'advancedforms') }}</option>
@@ -108,11 +197,11 @@
                                             {% if value is iterable %}
                                                 <optgroup label="{{ group_or_key }}">
                                                     {% for item_fqcn, name in value %}
-                                                        <option value="{{ item_fqcn }}" {{ col[COL_ITEMTYPE] == item_fqcn ? 'selected' : '' }}>{{ name }}</option>
+                                                        <option value="{{ item_fqcn }}">{{ name }}</option>
                                                     {% endfor %}
                                                 </optgroup>
                                             {% else %}
-                                                <option value="{{ group_or_key }}" {{ col[COL_ITEMTYPE] == group_or_key ? 'selected' : '' }}>{{ value }}</option>
+                                                <option value="{{ group_or_key }}">{{ value }}</option>
                                             {% endif %}
                                         {% endfor %}
                                     </select>
@@ -127,10 +216,9 @@
                                 <input
                                     type="checkbox"
                                     class="visually-hidden"
-                                    name="extra_data[columns][{{ index }}][{{ COL_REQUIRED }}]"
+                                    name="extra_data[columns][__INDEX__][{{ COL_REQUIRED }}]"
                                     value="1"
                                     aria-label="{{ __('Required column', 'advancedforms') }}"
-                                    {{ col[COL_REQUIRED] ? 'checked' : '' }}
                                 >
                                 <i class="ti ti-asterisk" aria-hidden="true"></i>
                             </label>
@@ -144,76 +232,18 @@
                                 data-af-table-column-remove
                             ></i>
                         </div>
-                    {% endfor %}
-                </div>
-
-                {# Template cloned by JS for new columns #}
-                <template data-af-table-column-template="{{ rand }}">
-                    <div class="d-flex align-items-center gap-2 mb-2" data-af-table-column>
-                        <input
-                            class="form-control"
-                            style="flex: 1 1 auto; min-width: 0; width: auto"
-                            type="text"
-                            name="extra_data[columns][__INDEX__][{{ COL_NAME }}]"
-                            placeholder="{{ __('Column name', 'advancedforms') }}"
-                        >
-                        <select
-                            class="form-select"
-                            style="width: 200px; flex-shrink: 0"
-                            name="extra_data[columns][__INDEX__][{{ COL_QUESTION_TYPE }}]"
-                            data-af-table-type-select
-                        >
-                            {% for fqcn, label in compatible_types %}
-                                <option value="{{ fqcn }}">{{ label }}</option>
-                            {% endfor %}
-                        </select>
-                        {% for type_fqcn, options in itemtype_options %}
-                            <div data-af-itemtype-wrapper="{{ type_fqcn }}" style="display: none">
-                                <select
-                                    class="form-select flex-shrink-0"
-                                    style="width: 170px"
-                                    name="extra_data[columns][__INDEX__][{{ COL_ITEMTYPE }}]"
-                                    disabled
-                                >
-                                    <option value="">{{ __('Select a type', 'advancedforms') }}</option>
-                                    {% for group_or_key, value in options %}
-                                        {% if value is iterable %}
-                                            <optgroup label="{{ group_or_key }}">
-                                                {% for item_fqcn, name in value %}
-                                                    <option value="{{ item_fqcn }}">{{ name }}</option>
-                                                {% endfor %}
-                                            </optgroup>
-                                        {% else %}
-                                            <option value="{{ group_or_key }}">{{ value }}</option>
-                                        {% endif %}
-                                    {% endfor %}
-                                </select>
-                            </div>
-                        {% endfor %}
-                        <label
-                            class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
-                            data-bs-toggle="tooltip"
-                            data-bs-placement="top"
-                            title="{{ __('Required column', 'advancedforms') }}"
-                        >
+                        <div class="mt-1" data-af-pattern-wrapper style="display: none">
                             <input
-                                type="checkbox"
-                                class="visually-hidden"
-                                name="extra_data[columns][__INDEX__][{{ COL_REQUIRED }}]"
-                                value="1"
-                                aria-label="{{ __('Required column', 'advancedforms') }}"
+                                class="form-control form-control-sm"
+                                type="text"
+                                name="extra_data[columns][__INDEX__][{{ COL_PATTERN }}]"
+                                placeholder="/regex/"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                title="{{ __('Validation pattern', 'advancedforms') }}"
+                                aria-label="{{ __('Validation pattern', 'advancedforms') }}"
                             >
-                            <i class="ti ti-asterisk" aria-hidden="true"></i>
-                        </label>
-                        <i
-                            role="button"
-                            class="ti ti-trash ms-1 cursor-pointer text-danger flex-shrink-0"
-                            data-bs-toggle="tooltip"
-                            data-bs-placement="top"
-                            title="{{ __('Remove column', 'advancedforms') }}"
-                            aria-label="{{ __('Remove column', 'advancedforms') }}"
-                            data-af-table-column-remove
-                        ></i>
+                        </div>
                     </div>
                 </template>
 

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -1,0 +1,271 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% set rand = random() %}
+
+<script>
+    window.afTableColumnTypeTemplate = window.afTableColumnTypeTemplate || function (item) {
+        const icons = {{ icons_json|raw }};
+        if (!item.id || !icons[item.id]) {
+            return item.text;
+        }
+        return $('<span>', { 'class': 'd-flex align-items-center gap-1' })
+            .append($('<i>', { 'class': icons[item.id] }))
+            .append(document.createTextNode(' ' + item.text));
+    };
+</script>
+
+<div class="dropdown" data-glpi-form-editor-question-extra-details>
+    <button
+        id="af-table-cfg-{{ rand }}"
+        class="btn btn-icon"
+        type="button"
+        data-bs-toggle="dropdown"
+        data-bs-auto-close="outside"
+        aria-expanded="false"
+        title="{{ __('Configure table columns', 'advancedforms') }}"
+        aria-label="{{ __('Configure table columns', 'advancedforms') }}"
+    >
+        <i class="ti ti-settings"></i>
+    </button>
+    <div
+        style="width: 52rem"
+        class="dropdown-menu dropdown-menu-end dropdown-menu-card animate__animated animate__zoomIn"
+        role="menu"
+        aria-labelledby="af-table-cfg-{{ rand }}"
+    >
+        <div class="card">
+            <div class="card-body">
+
+                <p class="fw-semibold mb-2">{{ __('Columns', 'advancedforms') }}</p>
+
+                <div
+                    class="mb-3"
+                    data-af-table-columns-container="{{ rand }}"
+                >
+                    {% for index, col in config.getColumns() %}
+                        <div class="d-flex align-items-center gap-2 mb-2" data-af-table-column>
+                            <input
+                                class="form-control"
+                                style="flex: 1 1 auto; min-width: 0; width: auto"
+                                type="text"
+                                name="extra_data[columns][{{ index }}][{{ COL_NAME }}]"
+                                value="{{ col[COL_NAME] }}"
+                                placeholder="{{ __('Column name', 'advancedforms') }}"
+                            >
+                            {% set col_select %}
+                                {% do call('Dropdown::showFromArray', [
+                                    'extra_data[columns][' ~ index ~ '][' ~ COL_QUESTION_TYPE ~ ']',
+                                    compatible_types,
+                                    {
+                                        'value'             : col[COL_QUESTION_TYPE],
+                                        'class'             : 'form-select',
+                                        'width'             : '200px',
+                                        'templateResult'    : 'window.afTableColumnTypeTemplate',
+                                        'templateSelection' : 'window.afTableColumnTypeTemplate',
+                                    }
+                                ]) %}
+                            {% endset %}
+                            {{ col_select|raw }}
+                            {% for type_fqcn, options in itemtype_options %}
+                                <div data-af-itemtype-wrapper="{{ type_fqcn }}" style="display: none">
+                                    <select
+                                        class="form-select flex-shrink-0"
+                                        style="width: 170px"
+                                        name="extra_data[columns][{{ index }}][{{ COL_ITEMTYPE }}]"
+                                        disabled
+                                    >
+                                        <option value="">{{ __('Select a type', 'advancedforms') }}</option>
+                                        {% for group_or_key, value in options %}
+                                            {% if value is iterable %}
+                                                <optgroup label="{{ group_or_key }}">
+                                                    {% for item_fqcn, name in value %}
+                                                        <option value="{{ item_fqcn }}" {{ col[COL_ITEMTYPE] == item_fqcn ? 'selected' : '' }}>{{ name }}</option>
+                                                    {% endfor %}
+                                                </optgroup>
+                                            {% else %}
+                                                <option value="{{ group_or_key }}" {{ col[COL_ITEMTYPE] == group_or_key ? 'selected' : '' }}>{{ value }}</option>
+                                            {% endif %}
+                                        {% endfor %}
+                                    </select>
+                                </div>
+                            {% endfor %}
+                            <label class="d-flex align-items-center gap-1 mb-0 text-nowrap">
+                                <input
+                                    type="checkbox"
+                                    class="form-check-input"
+                                    name="extra_data[columns][{{ index }}][{{ COL_REQUIRED }}]"
+                                    value="1"
+                                    {{ col[COL_REQUIRED] ? 'checked' : '' }}
+                                >
+                                {{ __('Req.', 'advancedforms') }}
+                            </label>
+                            <i
+                                role="button"
+                                class="ti ti-trash ms-1 cursor-pointer text-danger flex-shrink-0"
+                                data-bs-toggle="tooltip"
+                                data-bs-placement="top"
+                                title="{{ __('Remove column', 'advancedforms') }}"
+                                aria-label="{{ __('Remove column', 'advancedforms') }}"
+                                data-af-table-column-remove
+                            ></i>
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# Template cloned by JS for new columns #}
+                <template data-af-table-column-template="{{ rand }}">
+                    <div class="d-flex align-items-center gap-2 mb-2" data-af-table-column>
+                        <input
+                            class="form-control"
+                            style="flex: 1 1 auto; min-width: 0; width: auto"
+                            type="text"
+                            name="extra_data[columns][__INDEX__][{{ COL_NAME }}]"
+                            placeholder="{{ __('Column name', 'advancedforms') }}"
+                        >
+                        <select
+                            class="form-select"
+                            style="width: 200px; flex-shrink: 0"
+                            name="extra_data[columns][__INDEX__][{{ COL_QUESTION_TYPE }}]"
+                            data-af-table-type-select
+                        >
+                            {% for fqcn, label in compatible_types %}
+                                <option value="{{ fqcn }}">{{ label }}</option>
+                            {% endfor %}
+                        </select>
+                        {% for type_fqcn, options in itemtype_options %}
+                            <div data-af-itemtype-wrapper="{{ type_fqcn }}" style="display: none">
+                                <select
+                                    class="form-select flex-shrink-0"
+                                    style="width: 170px"
+                                    name="extra_data[columns][__INDEX__][{{ COL_ITEMTYPE }}]"
+                                    disabled
+                                >
+                                    <option value="">{{ __('Select a type', 'advancedforms') }}</option>
+                                    {% for group_or_key, value in options %}
+                                        {% if value is iterable %}
+                                            <optgroup label="{{ group_or_key }}">
+                                                {% for item_fqcn, name in value %}
+                                                    <option value="{{ item_fqcn }}">{{ name }}</option>
+                                                {% endfor %}
+                                            </optgroup>
+                                        {% else %}
+                                            <option value="{{ group_or_key }}">{{ value }}</option>
+                                        {% endif %}
+                                    {% endfor %}
+                                </select>
+                            </div>
+                        {% endfor %}
+                        <label class="d-flex align-items-center gap-1 mb-0 text-nowrap">
+                            <input
+                                type="checkbox"
+                                class="form-check-input"
+                                name="extra_data[columns][__INDEX__][{{ COL_REQUIRED }}]"
+                                value="1"
+                            >
+                            {{ __('Req.', 'advancedforms') }}
+                        </label>
+                        <i
+                            role="button"
+                            class="ti ti-trash ms-1 cursor-pointer text-danger flex-shrink-0"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            title="{{ __('Remove column', 'advancedforms') }}"
+                            aria-label="{{ __('Remove column', 'advancedforms') }}"
+                            data-af-table-column-remove
+                        ></i>
+                    </div>
+                </template>
+
+                <i
+                    role="button"
+                    class="ti ti-plus cursor-pointer mb-3"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="{{ __('Add column', 'advancedforms') }}"
+                    aria-label="{{ __('Add column', 'advancedforms') }}"
+                    data-af-table-column-add="{{ rand }}"
+                ></i>
+
+                <hr class="mt-3 mb-2">
+
+                <div class="d-flex gap-4 align-items-center flex-wrap">
+                    <label class="d-flex align-items-center gap-2 mb-0">
+                        <span class="text-nowrap">{{ __('Min rows', 'advancedforms') }}</span>
+                        <input
+                            type="number"
+                            class="form-control form-control-sm"
+                            style="width: 5rem"
+                            name="extra_data[{{ MIN_ROWS }}]"
+                            value="{{ config.getMinRows() }}"
+                            min="1"
+                            max="200"
+                            step="1"
+                        >
+                    </label>
+                    <label class="d-flex align-items-center gap-2 mb-0">
+                        <span class="text-nowrap">{{ __('Max rows', 'advancedforms') }}</span>
+                        <input
+                            type="number"
+                            class="form-control form-control-sm"
+                            style="width: 5rem"
+                            name="extra_data[{{ MAX_ROWS }}]"
+                            value="{{ config.getMaxRows() }}"
+                            min="1"
+                            max="200"
+                            step="1"
+                        >
+                    </label>
+                </div>
+
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    window.select2_configs = window.select2_configs || {};
+    window.select2_configs['af-table-type-template-{{ rand }}'] = {
+        type: 'adapt',
+        field_id: 'af-table-type-template-{{ rand }}',
+        width: '200px',
+        dropdown_css_class: '',
+        placeholder: '',
+        ajax_limit_count: {{ ajax_limit_count }},
+        templateresult: window.afTableColumnTypeTemplate,
+        templateselection: window.afTableColumnTypeTemplate,
+    };
+</script>
+
+<script type="module">
+    import { AfTableQuestionConfig } from '/plugins/advancedforms/js/modules/AfTableQuestionConfig.js';
+    new AfTableQuestionConfig();
+</script>

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -278,6 +278,6 @@
 </script>
 
 <script type="module">
-    import { AfTableQuestionConfig } from '/plugins/advancedforms/js/modules/AfTableQuestionConfig.js';
+    import { AfTableQuestionConfig } from '/plugins/advancedforms/js/modules/AfTableQuestionConfig.js?v={{ constant('PLUGIN_ADVANCEDFORMS_VERSION') }}';
     new AfTableQuestionConfig();
 </script>

--- a/templates/table_answer.html.twig
+++ b/templates/table_answer.html.twig
@@ -29,11 +29,11 @@
  # -------------------------------------------------------------------------
  #}
 
-<table class="table table-bordered table-sm">
+<table class="table table-sm">
     <thead>
         <tr>
             {% for header in headers %}
-                <th>{{ header }}</th>
+                <th class="border">{{ header }}</th>
             {% endfor %}
         </tr>
     </thead>
@@ -41,7 +41,7 @@
         {% for row in rows %}
             <tr>
                 {% for cell in row %}
-                    <td>{{ cell }}</td>
+                    <td class="border">{{ cell }}</td>
                 {% endfor %}
             </tr>
         {% endfor %}

--- a/templates/table_answer.html.twig
+++ b/templates/table_answer.html.twig
@@ -1,0 +1,49 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+<table class="table table-bordered table-sm">
+    <thead>
+        <tr>
+            {% for header in headers %}
+                <th>{{ header }}</th>
+            {% endfor %}
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
+            <tr>
+                {% for cell in row %}
+                    <td>{{ cell }}</td>
+                {% endfor %}
+            </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/templates/table_end_user.html.twig
+++ b/templates/table_end_user.html.twig
@@ -1,0 +1,186 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% set rand_eu    = random() %}
+{% set input_base = question.getEndUserInputName() %}
+{% set min_rows   = config.getMinRows() %}
+{% set max_rows   = config.getMaxRows() %}
+{% set columns    = config.getColumns() %}
+
+{% set required_cols = [] %}
+{% for col_index, col in columns %}
+    {% if col.required %}{% set required_cols = required_cols|merge([col_index]) %}{% endif %}
+{% endfor %}
+
+<div
+    data-af-table-question="{{ rand_eu }}"
+    data-af-min-rows="{{ min_rows }}"
+    data-af-max-rows="{{ max_rows }}"
+    data-af-s2-limit="{{ ajax_limit_count }}"
+    data-af-required-cols="{{ required_cols|join(',') }}"
+    data-af-required-msg="{{ __('Please fill in all required columns.', 'advancedforms') }}"
+>
+    <table class="table table-bordered table-sm mb-2">
+        <thead>
+            <tr>
+                {% for col in columns %}
+                    <th>
+                        {{ col.name }}
+                        {% if col.required %}<span class="text-danger" aria-hidden="true">*</span>{% endif %}
+                    </th>
+                {% endfor %}
+                <th style="width: 2.5rem"></th>
+            </tr>
+        </thead>
+        <tbody data-af-table-body>
+            {% for row_index in 0..(min_rows - 1) %}
+                <tr data-af-table-row>
+                    {% for col_index, col in columns %}
+                        {% set cell = column_cell_map[col_index] %}
+                        <td class="align-middle">
+                            {% if cell.mode == 'checkbox' %}
+                                <div class="d-flex justify-content-center">
+                                    <input
+                                        type="checkbox"
+                                        value="1"
+                                        class="form-check-input mt-0"
+                                        name="{{ input_base }}[{{ row_index }}][col_{{ col_index }}]"
+                                        {% if col.required %} required {% endif %}
+                                    >
+                                </div>
+                            {% elseif cell.mode == 'select' %}
+                                {% set sel_html %}
+                                    {% do call('Dropdown::showFromArray', [
+                                        input_base ~ '[' ~ row_index ~ '][col_' ~ col_index ~ ']',
+                                        cell.options,
+                                        {
+                                            'class'              : 'form-select form-select-sm',
+                                            'width'              : '100%',
+                                            'display_emptychoice': false,
+                                        }
+                                    ]) %}
+                                {% endset %}
+                                {{ sel_html|raw }}
+                            {% else %}
+                                <input
+                                    class="form-control form-control-sm"
+                                    type="{{ cell.input_type }}"
+                                    name="{{ input_base }}[{{ row_index }}][col_{{ col_index }}]"
+                                    placeholder="{{ col.name }}"
+                                    {% if col.required %} required {% endif %}
+                                >
+                            {% endif %}
+                        </td>
+                    {% endfor %}
+                    <td class="text-center align-middle">
+                        <i
+                            role="button"
+                            class="ti ti-trash cursor-pointer text-danger{% if min_rows >= max_rows %} opacity-25 pe-none{% endif %}"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            title="{{ __('Remove row', 'advancedforms') }}"
+                            aria-label="{{ __('Remove row', 'advancedforms') }}"
+                            data-af-table-remove-row
+                        ></i>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+    {# Template for cloning new rows #}
+    <template data-af-table-row-template>
+        <tr data-af-table-row>
+            {% for col_index, col in columns %}
+                {% set cell = column_cell_map[col_index] %}
+                <td class="align-middle">
+                    {% if cell.mode == 'checkbox' %}
+                        <div class="d-flex justify-content-center">
+                            <input
+                                type="checkbox"
+                                value="1"
+                                class="form-check-input mt-0"
+                                name="{{ input_base }}[__ROW__][col_{{ col_index }}]"
+                                {% if col.required %} required {% endif %}
+                            >
+                        </div>
+                    {% elseif cell.mode == 'select' %}
+                        <select
+                            class="form-select form-select-sm"
+                            name="{{ input_base }}[__ROW__][col_{{ col_index }}]"
+                            data-af-needs-s2
+                            {% if col.required %} required {% endif %}
+                        >
+                            {% for val, lbl in cell.options %}
+                                <option value="{{ val }}">{{ lbl }}</option>
+                            {% endfor %}
+                        </select>
+                    {% else %}
+                        <input
+                            class="form-control form-control-sm"
+                            type="{{ cell.input_type }}"
+                            name="{{ input_base }}[__ROW__][col_{{ col_index }}]"
+                            placeholder="{{ col.name }}"
+                            {% if col.required %} required {% endif %}
+                        >
+                    {% endif %}
+                </td>
+            {% endfor %}
+            <td class="text-center align-middle">
+                <i
+                    role="button"
+                    class="ti ti-trash cursor-pointer text-danger"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="{{ __('Remove row', 'advancedforms') }}"
+                    aria-label="{{ __('Remove row', 'advancedforms') }}"
+                    data-af-table-remove-row
+                ></i>
+            </td>
+        </tr>
+    </template>
+
+    <i
+        role="button"
+        class="ti ti-plus cursor-pointer{% if min_rows >= max_rows %} opacity-25 pe-none{% endif %}"
+        data-bs-toggle="tooltip"
+        data-bs-placement="top"
+        title="{{ __('Add a row', 'advancedforms') }}"
+        aria-label="{{ __('Add a row', 'advancedforms') }}"
+        data-af-table-add-row
+    ></i>
+</div>
+
+<script type="module">
+    import { AfTableQuestion } from '/plugins/advancedforms/js/modules/AfTableQuestion.js';
+    const el = document.querySelector('[data-af-table-question="{{ rand_eu|e('js') }}"]');
+    if (el) { new AfTableQuestion(el); }
+</script>

--- a/templates/table_end_user.html.twig
+++ b/templates/table_end_user.html.twig
@@ -106,6 +106,7 @@
                                     placeholder="{{ col.name }}"
                                     {% if col.required %} required {% endif %}
                                     {% if cell.pattern is defined and cell.pattern != '' %} pattern="{{ cell.pattern }}" {% endif %}
+                                    {% for attr_name, attr_value in cell.attributes|default({}) %} {{ attr_name }}="{{ attr_value }}" {% endfor %}
                                 >
                             {% endif %}
                         </td>
@@ -161,6 +162,7 @@
                             placeholder="{{ col.name }}"
                             {% if col.required %} required {% endif %}
                             {% if cell.pattern is defined and cell.pattern != '' %} pattern="{{ cell.pattern }}" {% endif %}
+                            {% for attr_name, attr_value in cell.attributes|default({}) %} {{ attr_name }}="{{ attr_value }}" {% endfor %}
                         >
                     {% endif %}
                 </td>

--- a/templates/table_end_user.html.twig
+++ b/templates/table_end_user.html.twig
@@ -40,6 +40,13 @@
     {% if col.required %}{% set required_cols = required_cols|merge([col_index]) %}{% endif %}
 {% endfor %}
 
+{% set pattern_cols = {} %}
+{% for col_index, col in columns %}
+    {% if col.pattern is defined and col.pattern != '' %}
+        {% set pattern_cols = pattern_cols|merge({(col_index): col.pattern}) %}
+    {% endif %}
+{% endfor %}
+
 <div
     data-af-table-question="{{ rand_eu }}"
     data-af-min-rows="{{ min_rows }}"
@@ -47,6 +54,8 @@
     data-af-s2-limit="{{ ajax_limit_count }}"
     data-af-required-cols="{{ required_cols|join(',') }}"
     data-af-required-msg="{{ __('Please fill in all required columns.', 'advancedforms') }}"
+    data-af-pattern-cols="{{ pattern_cols|json_encode|e('html_attr') }}"
+    data-af-pattern-msg="{{ __('This value does not match the expected format.', 'advancedforms') }}"
 >
     <table class="table table-bordered table-sm mb-2">
         <thead>
@@ -96,6 +105,7 @@
                                     name="{{ input_base }}[{{ row_index }}][col_{{ col_index }}]"
                                     placeholder="{{ col.name }}"
                                     {% if col.required %} required {% endif %}
+                                    {% if cell.pattern is defined and cell.pattern != '' %} pattern="{{ cell.pattern }}" {% endif %}
                                 >
                             {% endif %}
                         </td>
@@ -150,6 +160,7 @@
                             name="{{ input_base }}[__ROW__][col_{{ col_index }}]"
                             placeholder="{{ col.name }}"
                             {% if col.required %} required {% endif %}
+                            {% if cell.pattern is defined and cell.pattern != '' %} pattern="{{ cell.pattern }}" {% endif %}
                         >
                     {% endif %}
                 </td>

--- a/templates/table_end_user.html.twig
+++ b/templates/table_end_user.html.twig
@@ -180,7 +180,7 @@
 </div>
 
 <script type="module">
-    import { AfTableQuestion } from '/plugins/advancedforms/js/modules/AfTableQuestion.js';
+    import { AfTableQuestion } from '/plugins/advancedforms/js/modules/AfTableQuestion.js?v={{ constant('PLUGIN_ADVANCEDFORMS_VERSION') }}';
     const el = document.querySelector('[data-af-table-question="{{ rand_eu|e('js') }}"]');
     if (el) { new AfTableQuestion(el); }
 </script>

--- a/tests/Model/QuestionType/TableQuestionConfigTest.php
+++ b/tests/Model/QuestionType/TableQuestionConfigTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+
+final class TableQuestionConfigTest extends AdvancedFormsTestCase
+{
+    public function testDefaultValues(): void
+    {
+        $config = new TableQuestionConfig();
+        $this->assertSame([], $config->getColumns());
+        $this->assertSame(1, $config->getMinRows());
+        $this->assertSame(50, $config->getMaxRows());
+    }
+
+    public function testJsonRoundtrip(): void
+    {
+        $original = new TableQuestionConfig(
+            columns: [
+                ['name' => 'Source IP', 'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeShortText', 'required' => true,  'itemtype' => ''],
+                ['name' => 'Port',      'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeNumber',    'required' => false, 'itemtype' => ''],
+            ],
+            min_rows: 2,
+            max_rows: 20,
+        );
+        $serialized   = $original->jsonSerialize();
+        $deserialized = TableQuestionConfig::jsonDeserialize($serialized);
+        $this->assertSame($original->getColumns(), $deserialized->getColumns());
+        $this->assertSame($original->getMinRows(), $deserialized->getMinRows());
+        $this->assertSame($original->getMaxRows(), $deserialized->getMaxRows());
+    }
+
+    public function testJsonDeserializeFiltersNonArrayColumns(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize([
+            'columns'  => ['not_array', ['name' => 'Valid', 'question_type' => 'SomeFqcn', 'required' => false]],
+            'min_rows' => 1,
+            'max_rows' => 50,
+        ]);
+        $this->assertCount(1, $config->getColumns());
+        $this->assertSame('Valid', $config->getColumns()[0]['name']);
+    }
+
+    public function testJsonDeserializeEnforcesMinRow(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 0, 'max_rows' => 10]);
+        $this->assertSame(1, $config->getMinRows());
+    }
+
+    public function testJsonDeserializeEnforcesMaxRowNotZero(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 1, 'max_rows' => 0]);
+        $this->assertSame(1, $config->getMaxRows());
+    }
+}

--- a/tests/Model/QuestionType/TableQuestionConfigTest.php
+++ b/tests/Model/QuestionType/TableQuestionConfigTest.php
@@ -91,4 +91,10 @@ final class TableQuestionConfigTest extends AdvancedFormsTestCase
         $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 10, 'max_rows' => 5]);
         $this->assertSame(10, $config->getMaxRows());
     }
+
+    public function testJsonDeserializePreservesMaxRowAtCap(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 1, 'max_rows' => 50]);
+        $this->assertSame(50, $config->getMaxRows());
+    }
 }

--- a/tests/Model/QuestionType/TableQuestionConfigTest.php
+++ b/tests/Model/QuestionType/TableQuestionConfigTest.php
@@ -85,4 +85,10 @@ final class TableQuestionConfigTest extends AdvancedFormsTestCase
         $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 1, 'max_rows' => 0]);
         $this->assertSame(1, $config->getMaxRows());
     }
+
+    public function testJsonDeserializeEnforcesMaxRowNotLessThanMin(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize(['min_rows' => 10, 'max_rows' => 5]);
+        $this->assertSame(10, $config->getMaxRows());
+    }
 }

--- a/tests/Model/QuestionType/TableQuestionConfigTest.php
+++ b/tests/Model/QuestionType/TableQuestionConfigTest.php
@@ -50,8 +50,8 @@ final class TableQuestionConfigTest extends AdvancedFormsTestCase
     {
         $original = new TableQuestionConfig(
             columns: [
-                ['name' => 'Source IP', 'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeShortText', 'required' => true,  'itemtype' => ''],
-                ['name' => 'Port',      'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeNumber',    'required' => false, 'itemtype' => ''],
+                ['name' => 'Source IP', 'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeShortText', 'required' => true,  'itemtype' => '', 'pattern' => '/^172\\.23\\./'],
+                ['name' => 'Port',      'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeNumber',    'required' => false, 'itemtype' => '', 'pattern' => ''],
             ],
             min_rows: 2,
             max_rows: 20,
@@ -61,6 +61,17 @@ final class TableQuestionConfigTest extends AdvancedFormsTestCase
         $this->assertSame($original->getColumns(), $deserialized->getColumns());
         $this->assertSame($original->getMinRows(), $deserialized->getMinRows());
         $this->assertSame($original->getMaxRows(), $deserialized->getMaxRows());
+    }
+
+    public function testColumnPatternDefaultsToEmptyStringWhenAbsent(): void
+    {
+        $config = TableQuestionConfig::jsonDeserialize([
+            'columns' => [
+                ['name' => 'Source IP', 'question_type' => 'Glpi\\Form\\QuestionType\\QuestionTypeShortText', 'required' => true],
+            ],
+        ]);
+
+        $this->assertSame('', $config->getColumns()[0][TableQuestionConfig::COL_PATTERN]);
     }
 
     public function testJsonDeserializeFiltersNonArrayColumns(): void

--- a/tests/Model/QuestionType/TableQuestionIntegrationTest.php
+++ b/tests/Model/QuestionType/TableQuestionIntegrationTest.php
@@ -75,6 +75,11 @@ final class TableQuestionIntegrationTest extends QuestionTypeTestCase
     #[Override]
     protected function validateEditorRenderingWhenEnabled(Crawler $html): void
     {
+        // The admin preview marker lets plugin CSS hide the question-level
+        // "Mandatory" toggle (required is handled per column instead).
+        $question = $html->filter('[data-glpi-form-editor-question]')->first();
+        $this->assertGreaterThan(0, $question->filter('[data-af-table-admin]')->count());
+
         // Preview table must show column headers — use combined text to handle required asterisk span
         $headerText = implode(' ', $html->filter('th')->each(fn(Crawler $n) => $n->text()));
         $this->assertStringContainsString('Source IP', $headerText);

--- a/tests/Model/QuestionType/TableQuestionIntegrationTest.php
+++ b/tests/Model/QuestionType/TableQuestionIntegrationTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
+use GlpiPlugin\Advancedforms\Tests\QuestionType\QuestionTypeTestCase;
+use Override;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class TableQuestionIntegrationTest extends QuestionTypeTestCase
+{
+    #[Override]
+    protected function getTestedQuestionType(): QuestionTypeInterface&ConfigurableItemInterface
+    {
+        return new TableQuestion();
+    }
+
+    #[Override]
+    protected function getDefaultExtraDataForQuestionType(QuestionTypeInterface $type): ?string
+    {
+        return json_encode(new TableQuestionConfig(
+            columns: [
+                [
+                    TableQuestionConfig::COL_NAME          => 'Source IP',
+                    TableQuestionConfig::COL_QUESTION_TYPE => QuestionTypeShortText::class,
+                    TableQuestionConfig::COL_REQUIRED      => true,
+                ],
+                [
+                    TableQuestionConfig::COL_NAME          => 'Port',
+                    TableQuestionConfig::COL_QUESTION_TYPE => QuestionTypeNumber::class,
+                    TableQuestionConfig::COL_REQUIRED      => false,
+                ],
+            ],
+            min_rows: 1,
+            max_rows: 50,
+        ));
+    }
+
+    #[Override]
+    protected function validateEditorRenderingWhenEnabled(Crawler $html): void
+    {
+        // Preview table must show column headers — use combined text to handle required asterisk span
+        $headerText = implode(' ', $html->filter('th')->each(fn(Crawler $n) => $n->text()));
+        $this->assertStringContainsString('Source IP', $headerText);
+        $this->assertStringContainsString('Port', $headerText);
+
+        // Gear settings button must be present
+        $gear = $html->filter('[data-glpi-form-editor-question-extra-details]');
+        $this->assertNotEmpty($gear);
+    }
+
+    #[Override]
+    protected function validateHelpdeskRenderingWhenEnabled(Crawler $html): void
+    {
+        // Dynamic table container must exist
+        $container = $html->filter('[data-af-table-question]');
+        $this->assertNotEmpty($container);
+
+        // Required columns must be exposed to the client validation layer.
+        // The default config marks the first column ("Source IP") as required.
+        $this->assertSame('0', $container->attr('data-af-required-cols'));
+
+        // At least one input row rendered (min_rows = 1)
+        $rows = $html->filter('[data-af-table-body] [data-af-table-row]');
+        $this->assertGreaterThanOrEqual(1, $rows->count());
+
+        // Add-row button must be present
+        $addBtn = $html->filter('[data-af-table-add-row]');
+        $this->assertNotEmpty($addBtn);
+    }
+
+    #[Override]
+    protected function validateHelpdeskRenderingWhenDisabled(Crawler $html): void
+    {
+        $container = $html->filter('[data-af-table-question]');
+        $this->assertEmpty($container);
+    }
+}

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -1,0 +1,172 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeFile;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
+use Glpi\Form\QuestionType\QuestionTypeRequestType;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use GlpiPlugin\Advancedforms\Model\QuestionType\HiddenQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+
+final class TableQuestionTest extends AdvancedFormsTestCase
+{
+    private TableQuestion $type;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->type = new TableQuestion();
+    }
+
+    public function testPrepareExtraDataReindexesColumns(): void
+    {
+        $input = [
+            'columns' => [
+                5 => ['name' => 'A', 'question_type' => QuestionTypeShortText::class, 'required' => false],
+                9 => ['name' => 'B', 'question_type' => QuestionTypeNumber::class,    'required' => true],
+            ],
+            'min_rows' => '2',
+            'max_rows' => '20',
+        ];
+        $result = $this->type->prepareExtraData($input);
+        $this->assertArrayHasKey(0, $result[TableQuestionConfig::COLUMNS]);
+        $this->assertArrayHasKey(1, $result[TableQuestionConfig::COLUMNS]);
+        $this->assertSame(2, $result[TableQuestionConfig::MIN_ROWS]);
+        $this->assertSame(20, $result[TableQuestionConfig::MAX_ROWS]);
+    }
+
+    public function testPrepareExtraDataCoercesRequiredToBool(): void
+    {
+        $input = [
+            'columns'  => [['name' => 'X', 'question_type' => QuestionTypeShortText::class, 'required' => '1']],
+            'min_rows' => 1,
+            'max_rows' => 50,
+        ];
+        $result = $this->type->prepareExtraData($input);
+        $this->assertIsBool($result[TableQuestionConfig::COLUMNS][0][TableQuestionConfig::COL_REQUIRED]);
+        $this->assertTrue($result[TableQuestionConfig::COLUMNS][0][TableQuestionConfig::COL_REQUIRED]);
+    }
+
+    public function testCompatibleTypesExcludesFile(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(QuestionTypeFile::class, $types);
+    }
+
+    public function testCompatibleTypesExcludesSelf(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(TableQuestion::class, $types);
+    }
+
+    public function testCompatibleTypesIncludesShortText(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayHasKey(QuestionTypeShortText::class, $types);
+    }
+
+    public function testCellInfoForNumber(): void
+    {
+        $info = $this->type->getCellInfo(QuestionTypeNumber::class);
+        $this->assertSame('input', $info['mode']);
+        $this->assertSame('number', $info['input_type']);
+    }
+
+    public function testCellInfoForEmail(): void
+    {
+        $info = $this->type->getCellInfo(QuestionTypeEmail::class);
+        $this->assertSame('input', $info['mode']);
+        $this->assertSame('email', $info['input_type']);
+    }
+
+    public function testCellInfoDefaultsToText(): void
+    {
+        $info = $this->type->getCellInfo(QuestionTypeShortText::class);
+        $this->assertSame('input', $info['mode']);
+        $this->assertSame('text', $info['input_type']);
+    }
+
+    public function testCellInfoForCheckbox(): void
+    {
+        $info = $this->type->getCellInfo(QuestionTypeCheckbox::class);
+        $this->assertSame('checkbox', $info['mode']);
+    }
+
+    public function testCellInfoForHidden(): void
+    {
+        $info = $this->type->getCellInfo(HiddenQuestion::class, new HiddenQuestion());
+        $this->assertSame('input', $info['mode']);
+        $this->assertSame('hidden', $info['input_type']);
+    }
+
+    public function testCompatibleTypesExcludesRequestType(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(QuestionTypeRequestType::class, $types);
+    }
+
+    public function testCompatibleTypesExcludesLdap(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(LdapQuestion::class, $types);
+    }
+
+    public function testCompatibleTypesExcludesTreeCascadeDropdown(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(TreeCascadeDropdownQuestion::class, $types);
+    }
+
+    public function testGetConfigKey(): void
+    {
+        $this->assertSame('enable_question_type_table', TableQuestion::getConfigKey());
+    }
+
+    public function testGetIcon(): void
+    {
+        $this->assertSame('ti ti-table', $this->type->getIcon());
+    }
+
+    public function testGetExtraDataConfigClass(): void
+    {
+        $this->assertSame(TableQuestionConfig::class, $this->type->getExtraDataConfigClass());
+    }
+}

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -169,4 +169,34 @@ final class TableQuestionTest extends AdvancedFormsTestCase
     {
         $this->assertSame(TableQuestionConfig::class, $this->type->getExtraDataConfigClass());
     }
+
+    public function testValidateExtraDataInputAcceptsMaxRows50(): void
+    {
+        $result = $this->type->validateExtraDataInput([
+            'columns'  => [['name' => 'A', 'question_type' => QuestionTypeShortText::class]],
+            'min_rows' => 1,
+            'max_rows' => 50,
+        ]);
+        $this->assertTrue($result);
+    }
+
+    public function testValidateExtraDataInputRejectsMaxRowsAbove50(): void
+    {
+        $result = $this->type->validateExtraDataInput([
+            'columns'  => [['name' => 'A', 'question_type' => QuestionTypeShortText::class]],
+            'min_rows' => 1,
+            'max_rows' => 51,
+        ]);
+        $this->assertFalse($result);
+    }
+
+    public function testValidateExtraDataInputRejectsCraftedLargeMaxRows(): void
+    {
+        $result = $this->type->validateExtraDataInput([
+            'columns'  => [['name' => 'A', 'question_type' => QuestionTypeShortText::class]],
+            'min_rows' => 1,
+            'max_rows' => 99999,
+        ]);
+        $this->assertFalse($result);
+    }
 }

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -199,4 +199,14 @@ final class TableQuestionTest extends AdvancedFormsTestCase
         ]);
         $this->assertFalse($result);
     }
+
+    public function testPrepareExtraDataClampsMaxRowsTo50(): void
+    {
+        $result = $this->type->prepareExtraData([
+            'columns'  => [['name' => 'A', 'question_type' => QuestionTypeShortText::class, 'required' => false]],
+            'min_rows' => 1,
+            'max_rows' => 99999,
+        ]);
+        $this->assertSame(50, $result[TableQuestionConfig::MAX_ROWS]);
+    }
 }

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -209,4 +209,42 @@ final class TableQuestionTest extends AdvancedFormsTestCase
         ]);
         $this->assertSame(50, $result[TableQuestionConfig::MAX_ROWS]);
     }
+
+    public function testTransformConditionValueFlattensRowsToScalars(): void
+    {
+        $answer = [
+            ['col_0' => '172.23.0.15', 'col_1' => '172.23.1.10'],
+            ['col_0' => '172.23.0.20', 'col_1' => '172.23.1.30'],
+        ];
+        $result = $this->type->transformConditionValueForComparisons($answer, null);
+        $this->assertSame(['172.23.0.15', '172.23.1.10', '172.23.0.20', '172.23.1.30'], $result);
+    }
+
+    public function testTransformConditionValueSkipsEmptyCells(): void
+    {
+        $answer = [
+            ['col_0' => '172.23.0.15', 'col_1' => ''],
+        ];
+        $result = $this->type->transformConditionValueForComparisons($answer, null);
+        $this->assertSame(['172.23.0.15'], $result);
+    }
+
+    public function testTransformConditionValueEmptyTableReturnsEmptyArray(): void
+    {
+        $result = $this->type->transformConditionValueForComparisons([], null);
+        $this->assertSame([], $result);
+    }
+
+    public function testTransformConditionValueNonArrayReturnsString(): void
+    {
+        $result = $this->type->transformConditionValueForComparisons('raw', null);
+        $this->assertSame('raw', $result);
+    }
+
+    public function testTransformConditionValueSkipsNonArrayRows(): void
+    {
+        $answer = ['not_a_row', ['col_0' => '10.0.0.1']];
+        $result = $this->type->transformConditionValueForComparisons($answer, null);
+        $this->assertSame(['10.0.0.1'], $result);
+    }
 }

--- a/tests/Model/QuestionType/TableQuestionValidationTest.php
+++ b/tests/Model/QuestionType/TableQuestionValidationTest.php
@@ -35,11 +35,14 @@ namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
 
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Tests\FormBuilder;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+
+use function Safe\json_encode;
 
 final class TableQuestionValidationTest extends AdvancedFormsTestCase
 {
@@ -172,10 +175,118 @@ final class TableQuestionValidationTest extends AdvancedFormsTestCase
         }
     }
 
+    public function testColumnPatternMismatchProducesError(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/^172\.23\./'),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '10.0.0.1'],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->getErrors());
+    }
+
+    public function testColumnPatternMatchIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/^172\.23\./'),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '172.23.0.1'],
+        ]);
+
+        $this->assertTrue($result->isValid());
+        $this->assertCount(0, $result->getErrors());
+    }
+
+    public function testOptionalColumnWithPatternEmptyIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/^172\.23\./'),
+            $this->column('Comment', QuestionTypeShortText::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '', 'col_1' => 'a comment'],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testPatternAppliesOnlyToItsOwnColumn(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/^172\.23\./'),
+            $this->column('Checkbox', QuestionTypeShortText::class, required: false),
+            $this->column('Port', QuestionTypeShortText::class, required: false, pattern: '/^\d+$/'),
+        ]);
+
+        // Source IP is invalid, Checkbox has no pattern, Port is valid.
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '10.0.0.1', 'col_1' => 'anything', 'col_2' => '8080'],
+        ]);
+
+        $errors = $result->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Source IP', $errors[0]['message']);
+    }
+
+    public function testTwoIndependentColumnPatternsBothEnforced(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/^172\.23\./'),
+            $this->column('Port', QuestionTypeShortText::class, required: false, pattern: '/^\d+$/'),
+        ]);
+
+        // Both columns are invalid: two independent errors expected.
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '10.0.0.1', 'col_1' => 'not-a-port'],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(2, $result->getErrors());
+    }
+
+    public function testInvalidRegexPatternIsRejected(): void
+    {
+        $this->assertFalse($this->type->validateExtraDataInput([
+            'columns' => [
+                $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '/[/'),
+            ],
+        ]));
+    }
+
+    public function testNonSlashDelimitedPatternIsRejected(): void
+    {
+        // Valid PCRE with a non-`/` delimiter, but only `/…/` is stripped for HTML/JS.
+        $this->assertFalse($this->type->validateExtraDataInput([
+            'columns' => [
+                $this->column('Source IP', QuestionTypeShortText::class, required: false, pattern: '#^172\.23\.#'),
+            ],
+        ]));
+    }
+
+    public function testPatternIsIgnoredOnNonShortAnswerColumn(): void
+    {
+        // Config UI never exposes pattern for non-short-answer columns; a hand-crafted one must be ignored.
+        $question = $this->makeTableQuestion([
+            $this->column('Flag', QuestionTypeCheckbox::class, required: false, pattern: '/^yes$/'),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '1'],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
     public function testAnswersHandlerReportsMissingRequiredColumn(): void
     {
-        // The condition engine only validates questions visible to the current
-        // user, and plugin question types require authentication to be visible.
+        // The condition engine only validates visible questions; plugin types require authentication.
         $this->login();
         $this->enableConfigurableItem($this->type);
 
@@ -220,15 +331,16 @@ final class TableQuestionValidationTest extends AdvancedFormsTestCase
     }
 
     /**
-     * @return array{name: string, question_type: string, required: bool, itemtype: string}
+     * @return array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}
      */
-    private function column(string $name, string $fqcn, bool $required): array
+    private function column(string $name, string $fqcn, bool $required, string $pattern = ''): array
     {
         return [
             TableQuestionConfig::COL_NAME          => $name,
             TableQuestionConfig::COL_QUESTION_TYPE => $fqcn,
             TableQuestionConfig::COL_REQUIRED      => $required,
             TableQuestionConfig::COL_ITEMTYPE      => '',
+            TableQuestionConfig::COL_PATTERN       => $pattern,
         ];
     }
 }

--- a/tests/Model/QuestionType/TableQuestionValidationTest.php
+++ b/tests/Model/QuestionType/TableQuestionValidationTest.php
@@ -1,0 +1,234 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use Glpi\Form\AnswersHandler\AnswersHandler;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeShortText;
+use Glpi\Tests\FormBuilder;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+
+final class TableQuestionValidationTest extends AdvancedFormsTestCase
+{
+    private TableQuestion $type;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->type = new TableQuestion();
+    }
+
+    public function testRequiredColumnEmptyInFilledRowProducesError(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Name', QuestionTypeShortText::class, required: true),
+            $this->column('Comment', QuestionTypeShortText::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '', 'col_1' => 'a comment'],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->getErrors());
+    }
+
+    public function testAllRequiredColumnsFilledIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Name', QuestionTypeShortText::class, required: true),
+            $this->column('Comment', QuestionTypeShortText::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => 'Alice', 'col_1' => ''],
+        ]);
+
+        $this->assertTrue($result->isValid());
+        $this->assertCount(0, $result->getErrors());
+    }
+
+    public function testEntirelyEmptyRowIsSkipped(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Name', QuestionTypeShortText::class, required: true),
+            $this->column('Comment', QuestionTypeShortText::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '', 'col_1' => ''],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testOptionalColumnEmptyIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Name', QuestionTypeShortText::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => ''],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testErrorMessageMentionsColumnName(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Serial number', QuestionTypeShortText::class, required: true),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '', 'col_1' => 'filler'],
+        ]);
+
+        $errors = $result->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertStringContainsString('Serial number', $errors[0]['message']);
+    }
+
+    public function testNonArrayAnswerIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Name', QuestionTypeShortText::class, required: true),
+        ]);
+
+        $result = $this->type->validateAnswer($question, 'not-an-array');
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testMultipleMissingRequiredCellsProduceMultipleErrors(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('A', QuestionTypeShortText::class, required: true),
+            $this->column('B', QuestionTypeShortText::class, required: true),
+        ]);
+
+        // Row 1: A missing. Row 2: B missing. Row 3: entirely empty (ignored).
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '',     'col_1' => 'b1'],
+            ['col_0' => 'a2',   'col_1' => ''],
+            ['col_0' => '',     'col_1' => ''],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(2, $result->getErrors());
+    }
+
+    public function testRequiredValidationCoversEveryCompatibleColumnType(): void
+    {
+        foreach (array_keys($this->type->getCompatibleQuestionTypes()) as $fqcn) {
+            $question = $this->makeTableQuestion([
+                $this->column('Mandatory', $fqcn, required: true),
+                $this->column('Filler', QuestionTypeShortText::class, required: false),
+            ]);
+
+            // Filler is filled so the row counts as non-empty, mandatory cell is empty.
+            $result = $this->type->validateAnswer($question, [
+                ['col_0' => '', 'col_1' => 'filled'],
+            ]);
+
+            $this->assertFalse(
+                $result->isValid(),
+                "Required validation should fail for column type {$fqcn}",
+            );
+        }
+    }
+
+    public function testAnswersHandlerReportsMissingRequiredColumn(): void
+    {
+        // The condition engine only validates questions visible to the current
+        // user, and plugin question types require authentication to be visible.
+        $this->login();
+        $this->enableConfigurableItem($this->type);
+
+        $builder = new FormBuilder('Validation form');
+        $builder->addQuestion(
+            'Table',
+            TableQuestion::class,
+            extra_data: json_encode(new TableQuestionConfig(
+                columns: [
+                    $this->column('Name', QuestionTypeShortText::class, required: true),
+                    $this->column('Comment', QuestionTypeShortText::class, required: false),
+                ],
+            )),
+        );
+        $form = $this->createForm($builder);
+        $question_id = $this->getQuestionId($form, 'Table');
+
+        // Row has data (the comment) but the mandatory "Name" cell is empty.
+        $result = AnswersHandler::getInstance()->validateAnswers($form, [
+            $question_id => [['col_0' => '', 'col_1' => 'a comment']],
+        ]);
+
+        $this->assertFalse($result->isValid());
+    }
+
+    /**
+     * @param array<array{name: string, question_type: string, required: bool, itemtype: string}> $columns
+     */
+    private function makeTableQuestion(array $columns): Question
+    {
+        $this->enableConfigurableItem($this->type);
+
+        $builder = new FormBuilder('Validation form');
+        $builder->addQuestion(
+            'Table',
+            TableQuestion::class,
+            extra_data: json_encode(new TableQuestionConfig(columns: $columns)),
+        );
+        $form = $this->createForm($builder);
+
+        return Question::getById($this->getQuestionId($form, 'Table'));
+    }
+
+    /**
+     * @return array{name: string, question_type: string, required: bool, itemtype: string}
+     */
+    private function column(string $name, string $fqcn, bool $required): array
+    {
+        return [
+            TableQuestionConfig::COL_NAME          => $name,
+            TableQuestionConfig::COL_QUESTION_TYPE => $fqcn,
+            TableQuestionConfig::COL_REQUIRED      => $required,
+            TableQuestionConfig::COL_ITEMTYPE      => '',
+        ];
+    }
+}

--- a/tests/Model/QuestionType/TableQuestionValidationTest.php
+++ b/tests/Model/QuestionType/TableQuestionValidationTest.php
@@ -36,6 +36,8 @@ namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
 use Glpi\Form\AnswersHandler\AnswersHandler;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeNumber;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Tests\FormBuilder;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
@@ -284,6 +286,73 @@ final class TableQuestionValidationTest extends AdvancedFormsTestCase
         $this->assertTrue($result->isValid());
     }
 
+    public function testNumberColumnRejectsNonNumericValue(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Quantity', QuestionTypeNumber::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => 'not-a-number'],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->getErrors());
+    }
+
+    public function testNumberColumnAcceptsNumericValue(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Quantity', QuestionTypeNumber::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => '42.5'],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testEmailColumnRejectsInvalidAddress(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Contact', QuestionTypeEmail::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => 'not-an-email'],
+        ]);
+
+        $this->assertFalse($result->isValid());
+        $this->assertCount(1, $result->getErrors());
+    }
+
+    public function testEmailColumnAcceptsValidAddress(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Contact', QuestionTypeEmail::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => 'user@example.com'],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testOptionalNumberColumnEmptyIsValid(): void
+    {
+        $question = $this->makeTableQuestion([
+            $this->column('Quantity', QuestionTypeNumber::class, required: false),
+        ]);
+
+        $result = $this->type->validateAnswer($question, [
+            ['col_0' => ''],
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
     public function testAnswersHandlerReportsMissingRequiredColumn(): void
     {
         // The condition engine only validates visible questions; plugin types require authentication.
@@ -329,6 +398,7 @@ final class TableQuestionValidationTest extends AdvancedFormsTestCase
 
         return Question::getById($this->getQuestionId($form, 'Table'));
     }
+
 
     /**
      * @return array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}

--- a/tests/e2e/fixtures/advancedforms_fixture.ts
+++ b/tests/e2e/fixtures/advancedforms_fixture.ts
@@ -1,0 +1,34 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+// Re-export the core GLPI fixture so plugin specs share the same authenticated
+// `test`/`expect` and the worker/profile/api helpers.
+export * from '../../../../../tests/e2e/fixtures/glpi_fixture';

--- a/tests/e2e/pages/AdvancedFormsTablePage.ts
+++ b/tests/e2e/pages/AdvancedFormsTablePage.ts
@@ -74,7 +74,7 @@ export class AdvancedFormsTablePage extends GlpiPage {
      */
     public async addColumn(
         question: Locator,
-        column: { name: string; type: string; required?: boolean },
+        column: { name: string; type: string; required?: boolean; pattern?: string },
     ): Promise<void> {
         await question.locator('[data-af-table-column-add]').click();
 
@@ -88,6 +88,12 @@ export class AdvancedFormsTablePage extends GlpiPage {
 
         if (column.required) {
             await row.locator('.af-required-toggle').click();
+        }
+
+        if (column.pattern) {
+            const pattern_input = row.locator('[data-af-pattern-wrapper] input');
+            await pattern_input.waitFor({ state: 'visible' });
+            await pattern_input.fill(column.pattern);
         }
     }
 

--- a/tests/e2e/pages/AdvancedFormsTablePage.ts
+++ b/tests/e2e/pages/AdvancedFormsTablePage.ts
@@ -1,0 +1,104 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+import { Locator, Page, expect } from '@playwright/test';
+import { GlpiPage } from '../../../../../tests/e2e/pages/GlpiPage';
+
+/**
+ * Page helpers for the "Table" question type: enabling it, configuring its
+ * columns in the editor and interacting with the rendered end-user table.
+ */
+export class AdvancedFormsTablePage extends GlpiPage {
+    private static readonly CONFIG_TAB =
+        'GlpiPlugin\\Advancedforms\\Model\\Config\\ConfigTab$1';
+
+    public constructor(page: Page) {
+        super(page);
+    }
+
+    /** Enables the Table question type from the plugin configuration page. */
+    public async enableTableQuestionType(): Promise<void> {
+        await this.page.goto(
+            `/front/config.form.php?forcetab=${AdvancedFormsTablePage.CONFIG_TAB}`,
+        );
+
+        const card = this.page
+            .locator('[data-testid^="feature-"]')
+            .filter({ hasText: 'Table question type' });
+        const toggle = card.getByTestId('feature-toggle');
+
+        if (!(await toggle.isChecked())) {
+            await toggle.check();
+            await this.getButton('Save').click();
+            await expect(card.getByTestId('feature-toggle')).toBeChecked();
+        }
+    }
+
+    /** Opens the column configuration dropdown of a table question in the editor. */
+    public async openColumnConfig(question: Locator): Promise<void> {
+        await question.getByRole('button', { name: 'Configure table columns' }).click();
+        await question.locator('[data-af-table-columns-container]').waitFor({ state: 'visible' });
+    }
+
+    /**
+     * Adds a column in the (already open) configuration dropdown.
+     * `type` is the visible label of a compatible question type (e.g. "Text").
+     */
+    public async addColumn(
+        question: Locator,
+        column: { name: string; type: string; required?: boolean },
+    ): Promise<void> {
+        await question.locator('[data-af-table-column-add]').click();
+
+        const row = question.locator('[data-af-table-column]').last();
+        await row.getByPlaceholder('Column name').fill(column.name);
+
+        // Column type is a select2-enhanced <select>.
+        const type_dropdown = row.locator('.select2-container').first();
+        await type_dropdown.waitFor({ state: 'visible' });
+        await this.doSetDropdownValue(type_dropdown, column.type, false);
+
+        if (column.required) {
+            await row.locator('.af-required-toggle').click();
+        }
+    }
+
+    /** The rendered end-user table container. */
+    public getEndUserTable(): Locator {
+        return this.page.locator('[data-af-table-question]');
+    }
+
+    /** A cell control of the rendered end-user table, by row and column index. */
+    public getEndUserCell(table: Locator, row: number, col: number): Locator {
+        // eslint-disable-next-line playwright/no-raw-locators
+        return table.locator(`[name$="[${row}][col_${col}]"]`);
+    }
+}

--- a/tests/e2e/specs/table_question.spec.ts
+++ b/tests/e2e/specs/table_question.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+import { randomUUID } from 'crypto';
+import { test, expect, Page } from '../fixtures/advancedforms_fixture';
+import { FormPage } from '../../../../../tests/e2e/pages/FormPage';
+import { Profiles } from '../../../../../tests/e2e/utils/Profiles';
+import { getWorkerEntityId } from '../../../../../tests/e2e/utils/WorkerEntities';
+import { AdvancedFormsTablePage } from '../pages/AdvancedFormsTablePage';
+
+/**
+ * Builds a form with a single Table question through the editor and returns its id.
+ * The table has a required "Name" column and an optional "Comment" column,
+ * both rendered as plain text inputs.
+ */
+async function createFormWithTableQuestion(
+    page: Page,
+    api: { createItem(itemtype: string, fields: object): Promise<number> },
+    form_name: string,
+): Promise<number> {
+    const form = new FormPage(page);
+    const table = new AdvancedFormsTablePage(page);
+
+    await table.enableTableQuestionType();
+
+    const form_id = await api.createItem('Glpi\\Form\\Form', {
+        name: form_name,
+        entities_id: getWorkerEntityId(),
+    });
+    await form.goto(form_id);
+
+    const question = await form.addQuestion('Devices');
+    await form.doChangeQuestionType(question, 'Table');
+
+    await table.openColumnConfig(question);
+    await table.addColumn(question, { name: 'Name', type: 'Text', required: true });
+    await table.addColumn(question, { name: 'Comment', type: 'Text', required: false });
+
+    await form.doSaveFormEditor();
+
+    return form_id;
+}
+
+test.describe('Advanced forms - Table question', () => {
+    test('admin can configure and persist table columns', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const form = new FormPage(page);
+        const form_id = await createFormWithTableQuestion(
+            page,
+            api,
+            `E2E table config - ${randomUUID()}`,
+        );
+
+        // Reload the editor and check the columns survived the roundtrip.
+        await form.goto(form_id);
+        const question = page.getByRole('region', { name: 'Question details' }).first();
+        await expect(question.getByText('Name')).toBeVisible();
+        await expect(question.getByText('Comment')).toBeVisible();
+    });
+
+    test('end user can fill and submit the table', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const form = new FormPage(page);
+        const table = new AdvancedFormsTablePage(page);
+        const form_name = `E2E table submit - ${randomUUID()}`;
+
+        await createFormWithTableQuestion(page, api, form_name);
+        await form.doPreviewForm();
+
+        const eu_table = table.getEndUserTable();
+        await table.getEndUserCell(eu_table, 0, 0).fill('PC-001');
+        await table.getEndUserCell(eu_table, 0, 1).fill('Spare laptop');
+
+        await page.getByRole('button', { name: 'Submit' }).click();
+
+        // A link to the created answer/item confirms the submission succeeded.
+        await expect(page.getByRole('link', { name: form_name })).toBeVisible();
+    });
+
+    test('required column blocks submission and highlights the empty cell', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const form = new FormPage(page);
+        const table = new AdvancedFormsTablePage(page);
+
+        await createFormWithTableQuestion(page, api, `E2E table required - ${randomUUID()}`);
+        await form.doPreviewForm();
+
+        const eu_table = table.getEndUserTable();
+
+        // Fill only the optional column, leaving the required "Name" cell empty.
+        await table.getEndUserCell(eu_table, 0, 1).fill('Has a comment but no name');
+        await page.getByRole('button', { name: 'Submit' }).click();
+
+        // Submission is blocked: the error is shown and the empty required cell
+        // is highlighted, while the optional one is not.
+        await expect(eu_table.getByText('Please fill in all required columns.')).toBeVisible();
+        await expect(table.getEndUserCell(eu_table, 0, 0)).toHaveClass(/is-invalid/);
+        await expect(table.getEndUserCell(eu_table, 0, 1)).not.toHaveClass(/is-invalid/);
+
+        // Filling the required cell clears the error.
+        await table.getEndUserCell(eu_table, 0, 0).fill('PC-002');
+        await expect(table.getEndUserCell(eu_table, 0, 0)).not.toHaveClass(/is-invalid/);
+    });
+});

--- a/tests/e2e/specs/table_question.spec.ts
+++ b/tests/e2e/specs/table_question.spec.ts
@@ -119,14 +119,50 @@ test.describe('Advanced forms - Table question', () => {
         await table.getEndUserCell(eu_table, 0, 1).fill('Has a comment but no name');
         await page.getByRole('button', { name: 'Submit' }).click();
 
-        // Submission is blocked: the error is shown and the empty required cell
-        // is highlighted, while the optional one is not.
+        // Blocked: error shown, empty required cell highlighted, optional one is not.
         await expect(eu_table.getByText('Please fill in all required columns.')).toBeVisible();
         await expect(table.getEndUserCell(eu_table, 0, 0)).toHaveClass(/is-invalid/);
         await expect(table.getEndUserCell(eu_table, 0, 1)).not.toHaveClass(/is-invalid/);
 
         // Filling the required cell clears the error.
         await table.getEndUserCell(eu_table, 0, 0).fill('PC-002');
+        await expect(table.getEndUserCell(eu_table, 0, 0)).not.toHaveClass(/is-invalid/);
+    });
+
+    test('column pattern blocks submission and highlights the specific cell', async ({ page, profile, api }) => {
+        await profile.set(Profiles.SuperAdmin);
+        const form = new FormPage(page);
+        const table = new AdvancedFormsTablePage(page);
+
+        await table.enableTableQuestionType();
+
+        const form_id = await api.createItem('Glpi\\Form\\Form', {
+            name: `E2E table pattern - ${randomUUID()}`,
+            entities_id: getWorkerEntityId(),
+        });
+        await form.goto(form_id);
+
+        const question = await form.addQuestion('Devices');
+        await form.doChangeQuestionType(question, 'Table');
+
+        await table.openColumnConfig(question);
+        await table.addColumn(question, { name: 'Source IP', type: 'Text', required: false, pattern: '/^172\\.23\\./' });
+
+        await form.doSaveFormEditor();
+        await form.doPreviewForm();
+
+        const eu_table = table.getEndUserTable();
+
+        // Fill the cell with a value that does not match the configured pattern.
+        await table.getEndUserCell(eu_table, 0, 0).fill('10.0.0.1');
+        await page.getByRole('button', { name: 'Submit' }).click();
+
+        // Submission is blocked: the specific cell is highlighted with the pattern error.
+        await expect(eu_table.getByText('This value does not match the expected format.')).toBeVisible();
+        await expect(table.getEndUserCell(eu_table, 0, 0)).toHaveClass(/is-invalid/);
+
+        // Filling the cell with a matching value clears the error.
+        await table.getEndUserCell(eu_table, 0, 0).fill('172.23.0.1');
         await expect(table.getEndUserCell(eu_table, 0, 0)).not.toHaveClass(/is-invalid/);
     });
 });


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43740
- Here is a brief description of what this PR does

Adds a new **Table** question type to the plugin, letting form
designers collect tabular data with fully configurable columns.

## Changes

- **Configurable columns**: each column has a label, a cell type (reusing a compatible core question type), an optional item type, and a "required" flag.
- **Configurable rows**: min/max row count, with end users adding/removing rows dynamically.
- **End-user input**: renders an editable table; select-based cells (users, items, devices…) use select2.
- **Answer display**: stored answers are rendered back as a clean read-only table.
- **Required-column validation**:
  - Server-side (authoritative) via `QuestionTypeValidationInterface` — blocks submission when a filled row leaves a required cell empty.
  - Client-side — highlights only the offending cells (red border + message) and blocks the submit before the server round-trip.
- Disabled by default; enabled from the plugin configuration like the other advanced question types.

## Tests

- Unit + integration tests for config (de)serialization, compatible types, cell rendering, editor/helpdesk rendering, and required-column validation across **every** compatible column type.

## Screenshots (if appropriate):

<img width="839" height="259" alt="image" src="https://github.com/user-attachments/assets/f54b235f-e9ad-4096-922d-69c8192363b5" />

<img width="858" height="620" alt="image" src="https://github.com/user-attachments/assets/26bad5ac-0c0e-4553-9928-d83c7e1ba1bb" />

<img width="985" height="461" alt="image" src="https://github.com/user-attachments/assets/d1a62593-db01-4ab9-9fa8-545398b43aa5" />

<img width="982" height="479" alt="image" src="https://github.com/user-attachments/assets/b2e82961-2233-410a-aa49-42b462caefb8" />

### Fill form exemple :

<img width="985" height="454" alt="image" src="https://github.com/user-attachments/assets/29c6fdff-51cd-40f7-9f9d-9ff4040f1db3" />

<img width="718" height="423" alt="image" src="https://github.com/user-attachments/assets/576f69a5-c27e-4c9a-88c4-754169cafd62" />
