### PR TITLE
Fix: enforce subtree depth limit for tree cascade children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the `Tree cascade Dropdown` field so that the subtree depth limit is enforced when loading children via AJAX
+
 ## [1.1.1] - 2026-05-27
 
 ### Fixed

--- a/src/Controller/TreeDropdownChildrenController.php
+++ b/src/Controller/TreeDropdownChildrenController.php
@@ -87,8 +87,6 @@ final class TreeDropdownChildrenController extends AbstractController
         $foreign_key = $itemtype::getForeignKeyField();
         $table = $itemtype::getTable();
 
-        $level_key = $table . '.level';
-
         $where = [];
 
         $item_check = getItemForItemtype($itemtype);
@@ -100,7 +98,6 @@ final class TreeDropdownChildrenController extends AbstractController
         }
 
         if (!empty($condition_param) && is_array($condition_param)) {
-            unset($condition_param[$level_key]);
             $where = array_merge($where, $condition_param);
         }
 

--- a/tests/Model/QuestionType/TreeCascadeDropdownQuestionTest.php
+++ b/tests/Model/QuestionType/TreeCascadeDropdownQuestionTest.php
@@ -37,9 +37,11 @@ use Glpi\Form\QuestionType\QuestionTypeInterface;
 use Glpi\Form\QuestionType\QuestionTypeItemDropdownExtraDataConfig;
 use Glpi\Tests\FormBuilder;
 use Glpi\Tests\FormTesterTrait;
+use GlpiPlugin\Advancedforms\Controller\TreeDropdownChildrenController;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
 use GlpiPlugin\Advancedforms\Tests\QuestionType\QuestionTypeTestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Location;
 use Override;
 use Session;
@@ -500,6 +502,53 @@ final class TreeCascadeDropdownQuestionTest extends QuestionTypeTestCase
         foreach ($all_option_texts as $text) {
             $this->assertStringNotContainsString(' > ', $text);
         }
+    }
+
+    public function testSubtreeDepthIsEnforcedInChildrenController(): void
+    {
+        $this->login();
+        $this->enableConfigurableItem(TreeCascadeDropdownQuestion::class);
+
+        $entity_id = Session::getActiveEntity();
+        $level1 = $this->createItem(Location::class, [
+            'name'         => 'Level1',
+            'locations_id' => 0,
+            'entities_id'  => $entity_id,
+        ]);
+        $level2 = $this->createItem(Location::class, [
+            'name'         => 'Level2',
+            'locations_id' => $level1->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+        $level3 = $this->createItem(Location::class, [
+            'name'         => 'Level3',
+            'locations_id' => $level2->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+
+        $extra_data = json_encode(new QuestionTypeItemDropdownExtraDataConfig(
+            itemtype: Location::class,
+            subtree_depth: 2,
+        ));
+
+        $builder = new FormBuilder("Depth limit test");
+        $builder->addQuestion("Location", TreeCascadeDropdownQuestion::class, '', $extra_data);
+        $form = $this->createForm($builder);
+
+        $questions = $form->getQuestions();
+        $question = array_values($questions)[0];
+
+        $controller = new TreeDropdownChildrenController();
+
+        $response_level1_children = $controller->__invoke(
+            Request::create('', 'GET', ['questions_id' => $question->getID(), 'parent_id' => $level1->getID()]),
+        );
+        $this->assertStringContainsString('Level2', $response_level1_children->getContent());
+
+        $response_level2_children = $controller->__invoke(
+            Request::create('', 'GET', ['questions_id' => $question->getID(), 'parent_id' => $level2->getID()]),
+        );
+        $this->assertStringNotContainsString('Level3', $response_level2_children->getContent());
     }
 
     private function renderHelpdeskForm(\Glpi\Form\Form $form): Crawler

--- a/tests/Model/QuestionType/TreeCascadeDropdownQuestionTest.php
+++ b/tests/Model/QuestionType/TreeCascadeDropdownQuestionTest.php
@@ -504,6 +504,9 @@ final class TreeCascadeDropdownQuestionTest extends QuestionTypeTestCase
         }
     }
 
+    /**
+     * Verify that the subtree depth limit prevents children beyond the configured depth from being returned by the children controller.
+     */
     public function testSubtreeDepthIsEnforcedInChildrenController(): void
     {
         $this->login();
@@ -549,6 +552,59 @@ final class TreeCascadeDropdownQuestionTest extends QuestionTypeTestCase
             Request::create('', 'GET', ['questions_id' => $question->getID(), 'parent_id' => $level2->getID()]),
         );
         $this->assertStringNotContainsString('Level3', $response_level2_children->getContent());
+    }
+
+    /**
+     * Verify that when the parent itself exceeds the subtree depth limit, it is not selectable and no children are returned.
+     */
+    public function testParentExceedingDepthLimitIsNotSelectableAndHasNoChildren(): void
+    {
+        $this->login();
+        $this->enableConfigurableItem(TreeCascadeDropdownQuestion::class);
+
+        $entity_id = Session::getActiveEntity();
+        $level1 = $this->createItem(Location::class, [
+            'name'         => 'L1',
+            'locations_id' => 0,
+            'entities_id'  => $entity_id,
+        ]);
+        $level2 = $this->createItem(Location::class, [
+            'name'         => 'L2',
+            'locations_id' => $level1->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+        $level3 = $this->createItem(Location::class, [
+            'name'         => 'L3',
+            'locations_id' => $level2->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+        $this->createItem(Location::class, [
+            'name'         => 'L4',
+            'locations_id' => $level3->getID(),
+            'entities_id'  => $entity_id,
+        ]);
+
+        $extra_data = json_encode(new QuestionTypeItemDropdownExtraDataConfig(
+            itemtype: Location::class,
+            subtree_depth: 2,
+        ));
+
+        $builder = new FormBuilder("Depth selectable test");
+        $builder->addQuestion("Location", TreeCascadeDropdownQuestion::class, '', $extra_data);
+        $form = $this->createForm($builder);
+
+        $questions = $form->getQuestions();
+        $question = array_values($questions)[0];
+
+        $controller = new TreeDropdownChildrenController();
+
+        // Level3 exceeds subtree_depth=2; its child L4 must not be returned and
+        // the parent_is_selectable placeholder (value="0") must not appear.
+        $response = $controller->__invoke(
+            Request::create('', 'GET', ['questions_id' => $question->getID(), 'parent_id' => $level3->getID()]),
+        );
+        $this->assertStringNotContainsString('value="0"', $response->getContent());
+        $this->assertStringNotContainsString('L4', $response->getContent());
     }
 
     private function renderHelpdeskForm(\Glpi\Form\Form $form): Crawler


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45061

The `TreeDropdownChildrenController` was stripping the `level <= N` condition from the WHERE clause before querying child items, causing the subtree depth limit configured on a Tree Cascade Dropdown question to be silently ignored.
Removing the `unset` restores the restriction so that AJAX child loading respects the configured depth.

## Screenshots (if appropriate):
