### PR TITLE
Fix: correct answer and dropdown data handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fixed the `Hidden`, `IP address`, and `Hostname` questions to always use the correct value regardless of what was submitted, and restored the missing access check on the tree cascade dropdown children endpoint
+- Fixed the `LDAP select` question's autocomplete search to properly handle special characters in the search text
 - Fix visibility conditions on tree cascade dropdown questions
 - Fixed the `Tree cascade Dropdown` field so that the subtree depth limit is enforced when loading children via AJAX
 - Fixed the `Tree cascade Dropdown` question to only show items from the configured custom dropdown instead of all custom dropdowns

--- a/src/Controller/TreeDropdownChildrenController.php
+++ b/src/Controller/TreeDropdownChildrenController.php
@@ -39,6 +39,7 @@ use DBmysql;
 use CommonTreeDropdown;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Controller\AbstractController;
+use Glpi\Controller\Form\Utils\CanCheckAccessPolicies;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Symfony\Component\HttpFoundation\Request;
@@ -47,6 +48,8 @@ use Symfony\Component\Routing\Attribute\Route;
 
 final class TreeDropdownChildrenController extends AbstractController
 {
+    use CanCheckAccessPolicies;
+
     #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
     #[Route(
         path: 'TreeDropdownChildren',
@@ -65,6 +68,9 @@ final class TreeDropdownChildrenController extends AbstractController
         if (!$question->getFromDB($questions_id)) {
             return new Response('', Response::HTTP_OK);
         }
+
+        // Validate that the form is readable for the current user
+        $this->checkFormAccessPolicies($question->getForm(), $request);
 
         /** @var QuestionTypeItemDropdown $question_type */
         $question_type = $question->getQuestionType();

--- a/src/Model/Dropdown/LdapDropdown.php
+++ b/src/Model/Dropdown/LdapDropdown.php
@@ -144,10 +144,11 @@ final class LdapDropdown extends CommonGLPI
 
         // Insert search text into filter if specified
         if ($search_text !== '') {
+            $escaped_search_text = ldap_escape($search_text, '', LDAP_ESCAPE_FILTER);
             $ldap_filter = sprintf(
                 "(& %s (%s))",
                 $config->getLdapFilter(),
-                $attribute . '=*' . $search_text . '*',
+                $attribute . '=*' . $escaped_search_text . '*',
             );
         } else {
             $ldap_filter = $config->getLdapFilter();

--- a/src/Model/QuestionType/HiddenQuestion.php
+++ b/src/Model/QuestionType/HiddenQuestion.php
@@ -116,6 +116,13 @@ TWIG;
     }
 
     #[Override]
+    public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
+    {
+        // Ignore the submitted value: this field must never be attacker-controlled.
+        return $question->fields['default_value'];
+    }
+
+    #[Override]
     public static function getConfigKey(): string
     {
         return "enable_question_type_hidden";

--- a/src/Model/QuestionType/HostnameQuestion.php
+++ b/src/Model/QuestionType/HostnameQuestion.php
@@ -119,6 +119,13 @@ TWIG;
     }
 
     #[Override]
+    public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
+    {
+        // Ignore the submitted value: this field must never be attacker-controlled.
+        return gethostbyaddr(NetworkHelper::getRemoteIpAddress());
+    }
+
+    #[Override]
     public static function getConfigKey(): string
     {
         return "enable_question_type_hostname";

--- a/src/Model/QuestionType/IpAddressQuestion.php
+++ b/src/Model/QuestionType/IpAddressQuestion.php
@@ -119,6 +119,13 @@ TWIG;
     }
 
     #[Override]
+    public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
+    {
+        // Ignore the submitted value: this field must never be attacker-controlled.
+        return NetworkHelper::getRemoteIpAddress();
+    }
+
+    #[Override]
     public static function getConfigKey(): string
     {
         return "enable_question_type_ip_address";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Some question types could end up storing a value different from the one they are meant to always provide, depending on what was submitted.
This ensures those questions always return their intended value.
A dropdown data endpoint was also missing the same access check already applied to similar endpoints, and the directory search autocomplete did not handle some special characters correctly in the search text.

## Screenshots (if appropriate):
