### PR TITLE
Feat/reservation question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Add
 
+- Add Reservation question type
 - Add configurable table question type
 
 ### Fixed

--- a/public/js/modules/ReservationQuestionWidget.js
+++ b/public/js/modules/ReservationQuestionWidget.js
@@ -43,6 +43,24 @@ export class ReservationQuestionWidget {
 
         this.#initItemSelect();
         this.#initDateChangeListeners();
+        this.#initSubmitReset();
+    }
+
+    /**
+     * The form renderer validates each question server-side before submitting and
+     * surfaces any error next to the question, so clear our inline availability
+     * hint on submit to avoid showing duplicate or stale messaging.
+     */
+    #initSubmitReset() {
+        const form = this.#root.closest('form');
+        if (!form) {
+            return;
+        }
+
+        $(form).on('submit', () => this.#showAvailability(null));
+        $(form)
+            .find('[data-glpi-form-renderer-action="submit"]')
+            .on('click', () => this.#showAvailability(null));
     }
 
     #initItemSelect() {
@@ -56,7 +74,7 @@ export class ReservationQuestionWidget {
         $select.select2({
             width: '100%',
             allowClear: true,
-            placeholder: __('Select an item to reserve'),
+            placeholder: __('Select an item to reserve', 'advancedforms'),
             ajax: {
                 url: `${this.#endpoint_url}/ReservableItems`,
                 type: 'POST',
@@ -151,9 +169,32 @@ export class ReservationQuestionWidget {
             return;
         }
 
+        // Catch the obvious end-before-begin case locally, before asking the server.
+        if (!this.#isRangeValid(begin, end)) {
+            this.#showRangeError();
+            return;
+        }
+
         $.post(`${this.#endpoint_url}/CheckAvailability`, { reservationitems_id, begin, end })
             .done((data) => this.#showAvailability(data.available))
-            .fail(() => this.#showAvailability(null));
+            .fail(() => this.#showStatus(__('Could not check availability, please try again', 'advancedforms'), 'text-danger'));
+    }
+
+    /** @returns {boolean} false only when both dates parse and end is not strictly after begin. */
+    #isRangeValid(begin, end) {
+        const begin_ts = Date.parse(begin.replace(' ', 'T'));
+        const end_ts = Date.parse(end.replace(' ', 'T'));
+
+        if (Number.isNaN(begin_ts) || Number.isNaN(end_ts)) {
+            // Unparseable here: let the server-side validation decide.
+            return true;
+        }
+
+        return end_ts > begin_ts;
+    }
+
+    #showRangeError() {
+        this.#showStatus(__('The end date must be after the start date', 'advancedforms'), 'text-danger');
     }
 
     /** Fetches the equipment's existing reservations and lists them so the user can see busy slots. */
@@ -199,19 +240,27 @@ export class ReservationQuestionWidget {
     }
 
     #showAvailability(available) {
+        if (available === null || available === undefined) {
+            this.#showStatus('', null);
+            return;
+        }
+
+        this.#showStatus(
+            available ? __('This slot is available', 'advancedforms') : __('This slot is no longer available', 'advancedforms'),
+            available ? 'text-success' : 'text-danger',
+        );
+    }
+
+    /** Renders a single status line under the date pickers (availability, range error or request failure). */
+    #showStatus(text, css_class) {
         const $result = $(this.#root.querySelector('[data-reservation-question-availability]'));
         if ($result.length === 0) {
             return;
         }
 
-        if (available === null || available === undefined) {
-            $result.text('').removeClass('text-danger text-success');
-            return;
+        $result.text(text).removeClass('text-danger text-success');
+        if (css_class) {
+            $result.addClass(css_class);
         }
-
-        $result
-            .text(available ? __('This slot is available') : __('This slot is no longer available'))
-            .toggleClass('text-danger', !available)
-            .toggleClass('text-success', available);
     }
 }

--- a/public/js/modules/ReservationQuestionWidget.js
+++ b/public/js/modules/ReservationQuestionWidget.js
@@ -1,0 +1,186 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+export class ReservationQuestionWidget {
+    #root;
+    #endpoint_url = `${CFG_GLPI.root_doc}/plugins/advancedforms/ReservationWidget`;
+
+    /**
+     * @param {HTMLElement} root - The root element of the widget, as rendered
+     *  by `templates/reservation_question.html.twig`.
+     */
+    constructor(root) {
+        if (!root) {
+            return;
+        }
+
+        this.#root = root;
+
+        this.#initItemSelect();
+        this.#initDatePickers();
+    }
+
+    #initItemSelect() {
+        const $select = $(this.#root.querySelector('[data-reservation-question-item-select]'));
+        if ($select.length === 0) {
+            return;
+        }
+
+        const allowed_itemtypes = JSON.parse(this.#root.dataset.allowedItemtypes || '[]');
+
+        $select.select2({
+            width: '100%',
+            allowClear: true,
+            placeholder: __('Select an item to reserve'),
+            ajax: {
+                url: `${this.#endpoint_url}/ReservableItems`,
+                type: 'POST',
+                delay: 250,
+                data: (params) => ({
+                    allowed_itemtypes: allowed_itemtypes,
+                    search: params.term || '',
+                }),
+                processResults: (data) => ({
+                    results: this.#groupResultsByItemtype(Array.isArray(data) ? data : []),
+                }),
+            },
+        });
+
+        $select.on('select2:select', () => this.#onItemSelected());
+        $select.on('select2:clear select2:unselecting', () => this.#onItemCleared());
+    }
+
+    /**
+     * Group flat `{id, text, itemtype}` results into Select2 optgroups so
+     * items are presented per reservable itemtype.
+     *
+     * @param {Array<{id: number, text: string, itemtype: string}>} data
+     * @return {Array<{text: string, children: Array<{id: number, text: string}>}>}
+     */
+    #groupResultsByItemtype(data) {
+        const groups = new Map();
+
+        for (const item of data) {
+            const group_label = item.itemtype || '';
+            if (!groups.has(group_label)) {
+                groups.set(group_label, []);
+            }
+            groups.get(group_label).push({
+                id: item.id,
+                text: item.text,
+            });
+        }
+
+        return Array.from(groups, ([text, children]) => ({ text, children }));
+    }
+
+    #onItemSelected() {
+        const $select = $(this.#root.querySelector('[data-reservation-question-item-select]'));
+        this.#setFieldValue('reservationitems_id', $select.val());
+        $(this.#root.querySelector('[data-reservation-question-dates]')).removeClass('d-none');
+        this.#checkAvailability();
+    }
+
+    #onItemCleared() {
+        this.#setFieldValue('reservationitems_id', '');
+        this.#setFieldValue('begin', '');
+        this.#setFieldValue('end', '');
+        $(this.#root.querySelector('[data-reservation-question-dates]')).addClass('d-none');
+        this.#showAvailability(null);
+    }
+
+    #initDatePickers() {
+        const begin_input = this.#root.querySelector('[data-reservation-question-begin-picker]');
+        const end_input = this.#root.querySelector('[data-reservation-question-end-picker]');
+        if (!begin_input || !end_input) {
+            return;
+        }
+
+        const options = {
+            enableTime: true,
+            enableSeconds: true,
+            time_24hr: true,
+            dateFormat: 'Y-m-d H:i:S',
+            onChange: (selected_dates, date_str, instance) => {
+                const field = instance.element === begin_input ? 'begin' : 'end';
+                this.#setFieldValue(field, date_str);
+                this.#checkAvailability();
+            },
+        };
+
+        flatpickr(begin_input, options);
+        flatpickr(end_input, options);
+    }
+
+    #setFieldValue(field, value) {
+        const input = this.#root.querySelector(`[data-reservation-question-field="${field}"]`);
+        if (input) {
+            input.value = value ?? '';
+        }
+    }
+
+    #getFieldValue(field) {
+        const input = this.#root.querySelector(`[data-reservation-question-field="${field}"]`);
+        return input ? input.value : '';
+    }
+
+    #checkAvailability() {
+        const reservationitems_id = this.#getFieldValue('reservationitems_id');
+        const begin = this.#getFieldValue('begin');
+        const end = this.#getFieldValue('end');
+
+        if (!reservationitems_id || !begin || !end) {
+            this.#showAvailability(null);
+            return;
+        }
+
+        $.post(`${this.#endpoint_url}/CheckAvailability`, { reservationitems_id, begin, end })
+            .done((data) => this.#showAvailability(data.available))
+            .fail(() => this.#showAvailability(null));
+    }
+
+    #showAvailability(available) {
+        const $result = $(this.#root.querySelector('[data-reservation-question-availability]'));
+        if ($result.length === 0) {
+            return;
+        }
+
+        if (available === null || available === undefined) {
+            $result.text('').removeClass('text-danger text-success');
+            return;
+        }
+
+        $result
+            .text(available ? __('This slot is available') : __('This slot is no longer available'))
+            .toggleClass('text-danger', !available)
+            .toggleClass('text-success', available);
+    }
+}

--- a/public/js/modules/ReservationQuestionWidget.js
+++ b/public/js/modules/ReservationQuestionWidget.js
@@ -98,6 +98,7 @@ export class ReservationQuestionWidget {
         this.#setReservationItemsId($select.val());
         $(this.#root.querySelector('[data-reservation-question-dates]')).removeClass('d-none');
         this.#checkAvailability();
+        this.#loadReservations();
     }
 
     #onItemCleared() {
@@ -110,6 +111,7 @@ export class ReservationQuestionWidget {
         }
         $(this.#root.querySelector('[data-reservation-question-dates]')).addClass('d-none');
         this.#showAvailability(null);
+        this.#renderReservations([]);
     }
 
     /** begin/end are rendered by the datetimeField macro (self-initializing Flatpickr); just react to changes. */
@@ -152,6 +154,48 @@ export class ReservationQuestionWidget {
         $.post(`${this.#endpoint_url}/CheckAvailability`, { reservationitems_id, begin, end })
             .done((data) => this.#showAvailability(data.available))
             .fail(() => this.#showAvailability(null));
+    }
+
+    /** Fetches the equipment's existing reservations and lists them so the user can see busy slots. */
+    #loadReservations() {
+        const reservationitems_id = this.#root.querySelector('[data-reservation-question-field="reservationitems_id"]')?.value ?? '';
+        if (!reservationitems_id) {
+            this.#renderReservations([]);
+            return;
+        }
+
+        $.post(`${this.#endpoint_url}/Reservations`, { reservationitems_id })
+            .done((data) => this.#renderReservations(Array.isArray(data) ? data : []))
+            .fail(() => this.#renderReservations([]));
+    }
+
+    /** @param {Array<{begin: string, end: string}>} reservations */
+    #renderReservations(reservations) {
+        const container = this.#root.querySelector('[data-reservation-question-reservations]');
+        if (!container) {
+            return;
+        }
+
+        if (reservations.length === 0) {
+            container.innerHTML = '';
+            return;
+        }
+
+        const title = document.createElement('div');
+        title.className = 'text-muted small mb-1';
+        title.textContent = __('Existing reservations for this item', 'advancedforms');
+
+        const list = document.createElement('ul');
+        list.className = 'list-unstyled small mb-0';
+        for (const reservation of reservations) {
+            const line = document.createElement('li');
+            line.className = 'text-muted';
+            // textContent, never innerHTML: dates come from the server but stay untrusted here.
+            line.textContent = `${reservation.begin} → ${reservation.end}`;
+            list.appendChild(line);
+        }
+
+        container.replaceChildren(title, list);
     }
 
     #showAvailability(available) {

--- a/public/js/modules/ReservationQuestionWidget.js
+++ b/public/js/modules/ReservationQuestionWidget.js
@@ -33,10 +33,7 @@ export class ReservationQuestionWidget {
     #root;
     #endpoint_url = `${CFG_GLPI.root_doc}/plugins/advancedforms/ReservationWidget`;
 
-    /**
-     * @param {HTMLElement} root - The root element of the widget, as rendered
-     *  by `templates/reservation_question.html.twig`.
-     */
+    /** @param {HTMLElement} root - root element rendered by templates/reservation_question.html.twig */
     constructor(root) {
         if (!root) {
             return;
@@ -45,7 +42,7 @@ export class ReservationQuestionWidget {
         this.#root = root;
 
         this.#initItemSelect();
-        this.#initDatePickers();
+        this.#initDateChangeListeners();
     }
 
     #initItemSelect() {
@@ -78,13 +75,7 @@ export class ReservationQuestionWidget {
         $select.on('select2:clear select2:unselecting', () => this.#onItemCleared());
     }
 
-    /**
-     * Group flat `{id, text, itemtype}` results into Select2 optgroups so
-     * items are presented per reservable itemtype.
-     *
-     * @param {Array<{id: number, text: string, itemtype: string}>} data
-     * @return {Array<{text: string, children: Array<{id: number, text: string}>}>}
-     */
+    /** Groups flat {id, text, itemtype} results into Select2 optgroups per itemtype. */
     #groupResultsByItemtype(data) {
         const groups = new Map();
 
@@ -104,58 +95,54 @@ export class ReservationQuestionWidget {
 
     #onItemSelected() {
         const $select = $(this.#root.querySelector('[data-reservation-question-item-select]'));
-        this.#setFieldValue('reservationitems_id', $select.val());
+        this.#setReservationItemsId($select.val());
         $(this.#root.querySelector('[data-reservation-question-dates]')).removeClass('d-none');
         this.#checkAvailability();
     }
 
     #onItemCleared() {
-        this.#setFieldValue('reservationitems_id', '');
-        this.#setFieldValue('begin', '');
-        this.#setFieldValue('end', '');
+        this.#setReservationItemsId('');
+        if (this.#getBeginInput()) {
+            this.#getBeginInput().value = '';
+        }
+        if (this.#getEndInput()) {
+            this.#getEndInput().value = '';
+        }
         $(this.#root.querySelector('[data-reservation-question-dates]')).addClass('d-none');
         this.#showAvailability(null);
     }
 
-    #initDatePickers() {
-        const begin_input = this.#root.querySelector('[data-reservation-question-begin-picker]');
-        const end_input = this.#root.querySelector('[data-reservation-question-end-picker]');
+    /** begin/end are rendered by the datetimeField macro (self-initializing Flatpickr); just react to changes. */
+    #initDateChangeListeners() {
+        const begin_input = this.#getBeginInput();
+        const end_input = this.#getEndInput();
         if (!begin_input || !end_input) {
             return;
         }
 
-        const options = {
-            enableTime: true,
-            enableSeconds: true,
-            time_24hr: true,
-            dateFormat: 'Y-m-d H:i:S',
-            onChange: (selected_dates, date_str, instance) => {
-                const field = instance.element === begin_input ? 'begin' : 'end';
-                this.#setFieldValue(field, date_str);
-                this.#checkAvailability();
-            },
-        };
-
-        flatpickr(begin_input, options);
-        flatpickr(end_input, options);
+        $(begin_input).on('change', () => this.#checkAvailability());
+        $(end_input).on('change', () => this.#checkAvailability());
     }
 
-    #setFieldValue(field, value) {
-        const input = this.#root.querySelector(`[data-reservation-question-field="${field}"]`);
+    #getBeginInput() {
+        return this.#root.querySelector('[data-reservation-question-begin-picker]');
+    }
+
+    #getEndInput() {
+        return this.#root.querySelector('[data-reservation-question-end-picker]');
+    }
+
+    #setReservationItemsId(value) {
+        const input = this.#root.querySelector('[data-reservation-question-field="reservationitems_id"]');
         if (input) {
             input.value = value ?? '';
         }
     }
 
-    #getFieldValue(field) {
-        const input = this.#root.querySelector(`[data-reservation-question-field="${field}"]`);
-        return input ? input.value : '';
-    }
-
     #checkAvailability() {
-        const reservationitems_id = this.#getFieldValue('reservationitems_id');
-        const begin = this.#getFieldValue('begin');
-        const end = this.#getFieldValue('end');
+        const reservationitems_id = this.#root.querySelector('[data-reservation-question-field="reservationitems_id"]')?.value ?? '';
+        const begin = this.#getBeginInput()?.value ?? '';
+        const end = this.#getEndInput()?.value ?? '';
 
         if (!reservationitems_id || !begin || !end) {
             this.#showAvailability(null);

--- a/public/js/modules/ReservationRequestTimelineActions.js
+++ b/public/js/modules/ReservationRequestTimelineActions.js
@@ -1,0 +1,86 @@
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+export class ReservationRequestTimelineActions {
+    #root;
+    #endpoint_url = `${CFG_GLPI.root_doc}/plugins/advancedforms/ReservationRequest`;
+
+    /**
+     * @param {HTMLElement} root - The root element of a single timeline card,
+     *  as rendered by `templates/timeline/reservation_request.html.twig`.
+     */
+    constructor(root) {
+        if (!root) {
+            return;
+        }
+
+        this.#root = root;
+
+        this.#initButtons();
+    }
+
+    #initButtons() {
+        const $buttons = $(this.#root).find('[data-reservation-request-action]');
+        if ($buttons.length === 0) {
+            return;
+        }
+
+        $buttons.on('click', (e) => this.#onActionClicked($(e.currentTarget), $buttons));
+    }
+
+    #onActionClicked($button, $buttons) {
+        // Guard against double-submission while a request is in flight.
+        if ($buttons.prop('disabled')) {
+            return;
+        }
+
+        const id = $button.data('reservationRequestId');
+        const action = $button.data('reservationRequestAction');
+        const comment = $(this.#root).find('textarea[name="comment"]').val() ?? '';
+
+        $buttons.prop('disabled', true);
+
+        $.post(this.#endpoint_url, { id, action, comment })
+            .done((data) => {
+                if (data.success) {
+                    window.location.reload();
+                    return;
+                }
+
+                glpi_toast_error(data.message || __('An error occurred', 'advancedforms'));
+                $buttons.prop('disabled', false);
+            })
+            .fail(() => {
+                glpi_toast_error(__('An error occurred', 'advancedforms'));
+                $buttons.prop('disabled', false);
+            });
+    }
+}

--- a/public/js/modules/ReservationRequestTimelineActions.js
+++ b/public/js/modules/ReservationRequestTimelineActions.js
@@ -33,10 +33,7 @@ export class ReservationRequestTimelineActions {
     #root;
     #endpoint_url = `${CFG_GLPI.root_doc}/plugins/advancedforms/ReservationRequest`;
 
-    /**
-     * @param {HTMLElement} root - The root element of a single timeline card,
-     *  as rendered by `templates/timeline/reservation_request.html.twig`.
-     */
+    /** @param {HTMLElement} root - one timeline card, rendered by templates/timeline/reservation_request.html.twig */
     constructor(root) {
         if (!root) {
             return;

--- a/src/Controller/AbstractReservationWidgetController.php
+++ b/src/Controller/AbstractReservationWidgetController.php
@@ -35,6 +35,7 @@ namespace GlpiPlugin\Advancedforms\Controller;
 
 use Glpi\Controller\AbstractController;
 use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
 use ReservationItem;
 use Session;
 
@@ -47,5 +48,37 @@ abstract class AbstractReservationWidgetController extends AbstractController
         if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
             throw new AccessDeniedHttpException();
         }
+    }
+
+    /**
+     * Loads the reservable item and ensures it is active and within the
+     * current user's visible entities. The id is client-controlled, so it
+     * must never be trusted without this check.
+     *
+     * @throws BadRequestHttpException when the id is invalid or the item does not exist.
+     * @throws AccessDeniedHttpException when the item is inactive or outside visible entities.
+     */
+    protected function getAccessibleReservationItem(int $reservationitems_id): ReservationItem
+    {
+        $reservation_item = new ReservationItem();
+        if (
+            $reservationitems_id <= 0
+            || !$reservation_item->getFromDB($reservationitems_id)
+        ) {
+            throw new BadRequestHttpException();
+        }
+
+        $is_active = $reservation_item->fields['is_active'] ?? 0;
+        $entities_id = $reservation_item->fields['entities_id'] ?? -1;
+        $is_recursive = $reservation_item->fields['is_recursive'] ?? 0;
+
+        if (
+            !is_numeric($is_active) || (int) $is_active !== 1
+            || !is_numeric($entities_id) || !Session::haveAccessToEntity((int) $entities_id, (bool) $is_recursive)
+        ) {
+            throw new AccessDeniedHttpException();
+        }
+
+        return $reservation_item;
     }
 }

--- a/src/Controller/AbstractReservationWidgetController.php
+++ b/src/Controller/AbstractReservationWidgetController.php
@@ -33,37 +33,19 @@
 
 namespace GlpiPlugin\Advancedforms\Controller;
 
-use Glpi\Exception\Http\BadRequestHttpException;
-use Glpi\Http\Firewall;
-use Glpi\Security\Attribute\SecurityStrategy;
-use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Routing\Attribute\Route;
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use ReservationItem;
+use Session;
 
-final class CheckAvailabilityController extends AbstractReservationWidgetController
+/** Shared base for the reservation widget AJAX endpoints (common access guard). */
+abstract class AbstractReservationWidgetController extends AbstractController
 {
-    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
-    #[Route(
-        path: 'ReservationWidget/CheckAvailability',
-        name: 'reservation_widget_check_availability',
-        methods: 'POST',
-    )]
-    public function __invoke(Request $request): Response
+    /** @throws AccessDeniedHttpException when the current user cannot read reservations. */
+    protected function checkReservationAccess(): void
     {
-        $this->checkReservationAccess();
-
-        $reservationitems_id = $request->request->getInt('reservationitems_id');
-        $begin = $request->request->getString('begin');
-        $end = $request->request->getString('end');
-
-        if ($reservationitems_id <= 0 || $begin === '' || $end === '') {
-            throw new BadRequestHttpException();
+        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
+            throw new AccessDeniedHttpException();
         }
-
-        return new JsonResponse([
-            'available' => TicketReservationRequest::isSlotFree($reservationitems_id, $begin, $end),
-        ]);
     }
 }

--- a/src/Controller/CheckAvailabilityController.php
+++ b/src/Controller/CheckAvailabilityController.php
@@ -58,9 +58,11 @@ final class CheckAvailabilityController extends AbstractReservationWidgetControl
         $begin = $request->request->getString('begin');
         $end = $request->request->getString('end');
 
-        if ($reservationitems_id <= 0 || $begin === '' || $end === '') {
+        if ($begin === '' || $end === '') {
             throw new BadRequestHttpException();
         }
+
+        $this->getAccessibleReservationItem($reservationitems_id);
 
         return new JsonResponse([
             'available' => TicketReservationRequest::isSlotFree($reservationitems_id, $begin, $end),

--- a/src/Controller/CheckAvailabilityController.php
+++ b/src/Controller/CheckAvailabilityController.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Controller;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use Reservation;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class CheckAvailabilityController extends AbstractController
+{
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    #[Route(
+        path: 'ReservationWidget/CheckAvailability',
+        name: 'reservation_widget_check_availability',
+        methods: 'POST',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $reservationitems_id = $request->request->getInt('reservationitems_id');
+        $begin = $request->request->getString('begin');
+        $end = $request->request->getString('end');
+
+        if ($reservationitems_id <= 0 || $begin === '' || $end === '') {
+            throw new BadRequestHttpException();
+        }
+
+        global $DB;
+        $conflict = $DB->request([
+            'COUNT' => 'cpt',
+            'FROM' => Reservation::getTable(),
+            'WHERE' => [
+                'reservationitems_id' => $reservationitems_id,
+                'end' => ['>', $begin],
+                'begin' => ['<', $end],
+            ],
+        ])->current();
+
+        $count = 0;
+        if (is_array($conflict) && isset($conflict['cpt']) && is_numeric($conflict['cpt'])) {
+            $count = (int) $conflict['cpt'];
+        }
+
+        return new JsonResponse(['available' => $count === 0]);
+    }
+}

--- a/src/Controller/GetReservationsController.php
+++ b/src/Controller/GetReservationsController.php
@@ -33,7 +33,6 @@
 
 namespace GlpiPlugin\Advancedforms\Controller;
 
-use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Reservation;
@@ -55,17 +54,18 @@ final class GetReservationsController extends AbstractReservationWidgetControlle
         $this->checkReservationAccess();
 
         $reservationitems_id = $request->request->getInt('reservationitems_id');
-        if ($reservationitems_id <= 0) {
-            throw new BadRequestHttpException();
-        }
+        $this->getAccessibleReservationItem($reservationitems_id);
 
         $begin = $request->request->getString('begin', '');
         $end = $request->request->getString('end', '');
 
-        $where = ['reservationitems_id' => $reservationitems_id];
-        if ($begin !== '') {
-            $where['end'] = ['>', $begin];
-        }
+        // No lower bound given by the caller: only return current/future slots,
+        // never the item's whole reservation history.
+        $now = $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s');
+        $where = [
+            'reservationitems_id' => $reservationitems_id,
+            'end' => ['>', $begin !== '' ? $begin : $now],
+        ];
 
         if ($end !== '') {
             $where['begin'] = ['<', $end];
@@ -75,6 +75,8 @@ final class GetReservationsController extends AbstractReservationWidgetControlle
         $rows = $DB->request([
             'FROM' => Reservation::getTable(),
             'WHERE' => $where,
+            'ORDER' => 'begin ASC',
+            'LIMIT' => 100,
         ]);
 
         $results = [];
@@ -85,12 +87,10 @@ final class GetReservationsController extends AbstractReservationWidgetControlle
 
             $begin_value = $row['begin'] ?? null;
             $end_value = $row['end'] ?? null;
-            $users_id_value = $row['users_id'] ?? null;
 
             $results[] = [
                 'begin' => is_scalar($begin_value) ? (string) $begin_value : '',
                 'end' => is_scalar($end_value) ? (string) $end_value : '',
-                'users_id' => is_numeric($users_id_value) ? (int) $users_id_value : 0,
             ];
         }
 

--- a/src/Controller/GetReservationsController.php
+++ b/src/Controller/GetReservationsController.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Controller;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use Reservation;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class GetReservationsController extends AbstractController
+{
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    #[Route(
+        path: 'ReservationWidget/Reservations',
+        name: 'reservation_widget_reservations',
+        methods: 'POST',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $reservationitems_id = $request->request->getInt('reservationitems_id');
+        if ($reservationitems_id <= 0) {
+            throw new BadRequestHttpException();
+        }
+
+        $begin = $request->request->getString('begin', '');
+        $end = $request->request->getString('end', '');
+
+        $where = ['reservationitems_id' => $reservationitems_id];
+        if ($begin !== '') {
+            $where['end'] = ['>', $begin];
+        }
+        if ($end !== '') {
+            $where['begin'] = ['<', $end];
+        }
+
+        global $DB;
+        $rows = $DB->request([
+            'FROM' => Reservation::getTable(),
+            'WHERE' => $where,
+        ]);
+
+        $results = [];
+        foreach ($rows as $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+
+            $begin_value = $row['begin'] ?? null;
+            $end_value = $row['end'] ?? null;
+            $users_id_value = $row['users_id'] ?? null;
+
+            $results[] = [
+                'begin' => is_scalar($begin_value) ? (string) $begin_value : '',
+                'end' => is_scalar($end_value) ? (string) $end_value : '',
+                'users_id' => is_numeric($users_id_value) ? (int) $users_id_value : 0,
+            ];
+        }
+
+        return new JsonResponse($results);
+    }
+}

--- a/src/Controller/GetReservationsController.php
+++ b/src/Controller/GetReservationsController.php
@@ -72,6 +72,7 @@ final class GetReservationsController extends AbstractController
         if ($begin !== '') {
             $where['end'] = ['>', $begin];
         }
+
         if ($end !== '') {
             $where['begin'] = ['<', $end];
         }

--- a/src/Controller/GetReservationsController.php
+++ b/src/Controller/GetReservationsController.php
@@ -33,20 +33,16 @@
 
 namespace GlpiPlugin\Advancedforms\Controller;
 
-use Glpi\Controller\AbstractController;
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Exception\Http\BadRequestHttpException;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use Reservation;
-use ReservationItem;
-use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class GetReservationsController extends AbstractController
+final class GetReservationsController extends AbstractReservationWidgetController
 {
     #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
     #[Route(
@@ -56,9 +52,7 @@ final class GetReservationsController extends AbstractController
     )]
     public function __invoke(Request $request): Response
     {
-        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
-            throw new AccessDeniedHttpException();
-        }
+        $this->checkReservationAccess();
 
         $reservationitems_id = $request->request->getInt('reservationitems_id');
         if ($reservationitems_id <= 0) {

--- a/src/Controller/ReservableItemsController.php
+++ b/src/Controller/ReservableItemsController.php
@@ -34,19 +34,16 @@
 namespace GlpiPlugin\Advancedforms\Controller;
 
 use CommonDBTM;
-use Glpi\Controller\AbstractController;
 use Glpi\DBAL\QuerySubQuery;
-use Glpi\Exception\Http\AccessDeniedHttpException;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
 use ReservationItem;
-use Session;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Attribute\Route;
 
-final class ReservableItemsController extends AbstractController
+final class ReservableItemsController extends AbstractReservationWidgetController
 {
     #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
     #[Route(
@@ -56,9 +53,7 @@ final class ReservableItemsController extends AbstractController
     )]
     public function __invoke(Request $request): Response
     {
-        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
-            throw new AccessDeniedHttpException();
-        }
+        $this->checkReservationAccess();
 
         /** @var array<mixed> $allowed_itemtypes */
         $allowed_itemtypes = $request->request->all('allowed_itemtypes');

--- a/src/Controller/ReservableItemsController.php
+++ b/src/Controller/ReservableItemsController.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Controller;
+
+use CommonDBTM;
+use Glpi\Controller\AbstractController;
+use Glpi\DBAL\QuerySubQuery;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ReservableItemsController extends AbstractController
+{
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    #[Route(
+        path: 'ReservationWidget/ReservableItems',
+        name: 'reservation_widget_reservable_items',
+        methods: 'POST',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        if (!Session::haveRightsOr('reservation', [READ, ReservationItem::RESERVEANITEM])) {
+            throw new AccessDeniedHttpException();
+        }
+
+        /** @var array<mixed> $allowed_itemtypes */
+        $allowed_itemtypes = $request->request->all('allowed_itemtypes');
+        $search = $request->request->getString('search', '');
+
+        global $CFG_GLPI;
+        $reservation_types = $CFG_GLPI['reservation_types'] ?? [];
+        $itemtypes = $allowed_itemtypes !== []
+            ? $allowed_itemtypes
+            : (is_array($reservation_types) ? $reservation_types : []);
+
+        $results = [];
+        foreach ($itemtypes as $itemtype) {
+            if (!is_string($itemtype) || !is_a($itemtype, CommonDBTM::class, true)) {
+                continue;
+            }
+
+            $results = [...$results, ...$this->getReservableItemsForType($itemtype, $search)];
+        }
+
+        return new JsonResponse($results);
+    }
+
+    /**
+     * @param class-string<CommonDBTM> $itemtype
+     * @return array<int, array{id: int, text: string, itemtype: string}>
+     */
+    private function getReservableItemsForType(string $itemtype, string $search): array
+    {
+        global $DB;
+
+        $item = getItemForItemtype($itemtype);
+        $where = [
+            'itemtype' => $itemtype,
+            'is_active' => 1,
+        ];
+
+        if ($search !== '') {
+            $where['items_id'] = new QuerySubQuery([
+                'SELECT' => 'id',
+                'FROM' => $itemtype::getTable(),
+                'WHERE' => ['name' => ['LIKE', "%$search%"]],
+            ]);
+        }
+
+        $rows = $DB->request([
+            'FROM' => ReservationItem::getTable(),
+            'WHERE' => $where,
+        ]);
+
+        $results = [];
+        foreach ($rows as $row) {
+            if (!is_array($row) || !isset($row['items_id']) || !is_numeric($row['items_id'])) {
+                continue;
+            }
+
+            if (!$item->getFromDB((int) $row['items_id'])) {
+                continue;
+            }
+
+            $id = $row['id'] ?? null;
+            $results[] = [
+                'id' => is_numeric($id) ? (int) $id : 0,
+                'text' => sprintf('%s (%s)', $item->getName(), $itemtype::getTypeName(1)),
+                'itemtype' => $itemtype,
+            ];
+        }
+
+        return $results;
+    }
+}

--- a/src/Controller/ReservableItemsController.php
+++ b/src/Controller/ReservableItemsController.php
@@ -37,6 +37,7 @@ use CommonDBTM;
 use Glpi\DBAL\QuerySubQuery;
 use Glpi\Http\Firewall;
 use Glpi\Security\Attribute\SecurityStrategy;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionConfig;
 use ReservationItem;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -59,11 +60,9 @@ final class ReservableItemsController extends AbstractReservationWidgetControlle
         $allowed_itemtypes = $request->request->all('allowed_itemtypes');
         $search = $request->request->getString('search', '');
 
-        global $CFG_GLPI;
-        $reservation_types = $CFG_GLPI['reservation_types'] ?? [];
-        $itemtypes = $allowed_itemtypes !== []
-            ? $allowed_itemtypes
-            : (is_array($reservation_types) ? $reservation_types : []);
+        // Same fallback as the question config: given types, or all reservable types.
+        $allowed = array_values(array_filter($allowed_itemtypes, is_string(...)));
+        $itemtypes = (new ReservationQuestionConfig($allowed))->getEffectiveAllowedItemtypes();
 
         $results = [];
         foreach ($itemtypes as $itemtype) {

--- a/src/Controller/ReservableItemsController.php
+++ b/src/Controller/ReservableItemsController.php
@@ -88,7 +88,7 @@ final class ReservableItemsController extends AbstractReservationWidgetControlle
         $where = [
             'itemtype' => $itemtype,
             'is_active' => 1,
-        ];
+        ] + getEntitiesRestrictCriteria(ReservationItem::getTable(), 'entities_id', '', true);
 
         if ($search !== '') {
             $where['items_id'] = new QuerySubQuery([

--- a/src/Controller/ReservableItemsController.php
+++ b/src/Controller/ReservableItemsController.php
@@ -100,7 +100,7 @@ final class ReservableItemsController extends AbstractController
             $where['items_id'] = new QuerySubQuery([
                 'SELECT' => 'id',
                 'FROM' => $itemtype::getTable(),
-                'WHERE' => ['name' => ['LIKE', "%$search%"]],
+                'WHERE' => ['name' => ['LIKE', sprintf('%%%s%%', $search)]],
             ]);
         }
 

--- a/src/Controller/ReservationRequestController.php
+++ b/src/Controller/ReservationRequestController.php
@@ -72,8 +72,6 @@ final class ReservationRequestController extends AbstractController
             throw new AccessDeniedHttpException();
         }
 
-        // The controller requires an authenticated session (see the
-        // SecurityStrategy attribute above), so this is always a real user id.
         $users_id_validate = (int) Session::getLoginUserID();
 
         if ($action === 'approve') {

--- a/src/Controller/ReservationRequestController.php
+++ b/src/Controller/ReservationRequestController.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Controller;
+
+use Glpi\Controller\AbstractController;
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use Glpi\Http\Firewall;
+use Glpi\Security\Attribute\SecurityStrategy;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Session;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+final class ReservationRequestController extends AbstractController
+{
+    #[SecurityStrategy(Firewall::STRATEGY_AUTHENTICATED)]
+    #[Route(
+        path: 'ReservationRequest',
+        name: 'reservation_request',
+        methods: 'POST',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        $id = $request->request->getInt('id');
+        $action = $request->request->getString('action');
+        $comment = $request->request->getString('comment', '');
+
+        if ($id <= 0 || !in_array($action, ['approve', 'refuse'], true)) {
+            throw new BadRequestHttpException();
+        }
+
+        $reservation_request = new TicketReservationRequest();
+        if (!$reservation_request->getFromDB($id)) {
+            throw new BadRequestHttpException();
+        }
+
+        if (!$reservation_request->canAnswer()) {
+            throw new AccessDeniedHttpException();
+        }
+
+        // The controller requires an authenticated session (see the
+        // SecurityStrategy attribute above), so this is always a real user id.
+        $users_id_validate = (int) Session::getLoginUserID();
+
+        if ($action === 'approve') {
+            if (!$reservation_request->isSlotStillAvailable()) {
+                return new JsonResponse([
+                    'success' => false,
+                    'message' => __('This slot is no longer available.', 'advancedforms'),
+                ]);
+            }
+
+            $success = $reservation_request->approve($users_id_validate, $comment);
+        } else {
+            $success = $reservation_request->refuse($users_id_validate, $comment);
+        }
+
+        return new JsonResponse(['success' => $success]);
+    }
+}

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -176,7 +176,6 @@ final class PreReservationField extends AbstractConfigField
         }
 
         try {
-            // @phpstan-ignore argument.type (the exact shape is validated at runtime by fromArray() itself)
             $answer = ReservationQuestionAnswer::fromArray($raw_answer);
         } catch (InvalidArgumentException) {
             // Incomplete/invalid answer: do not block the ticket creation.

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -181,8 +181,9 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
-        $request = new TicketReservationRequest();
-        $request_id = $request->add([
+        $require_approval = $config->isApprovalRequired();
+
+        $add_input = [
             'tickets_id'          => $ticket->getID(),
             'reservationitems_id' => $answer->getReservationItemsId(),
             // @phpstan-ignore cast.int (CommonDBTM::$fields is not generically typed)
@@ -190,13 +191,30 @@ final class PreReservationField extends AbstractConfigField
             'begin'               => $answer->getBegin(),
             'end'                 => $answer->getEnd(),
             'status'              => TicketReservationRequest::STATUS_WAITING,
-        ]);
+        ];
+
+        if (!$require_approval) {
+            // In direct/no-approval mode, the WAITING status set above is
+            // only a transient step before immediately transitioning this
+            // request to its real final state below (ACCEPTED/CANCELED),
+            // which each raise their own distinct notification event. The
+            // request never actually waits for approval, so the "please wait
+            // for approval" notification must be suppressed for this insert.
+            // (The key must only be present when disabling: `isset()` is what
+            // `TicketReservationRequest::post_addItem()` checks, and it is
+            // `true` even for an explicit `false` value, matching the
+            // `_disablenotif` convention used throughout GLPI core.)
+            $add_input['_disablenotif'] = true;
+        }
+
+        $request = new TicketReservationRequest();
+        $request_id = $request->add($add_input);
 
         if (!$request_id) {
             return;
         }
 
-        if (!$config->isApprovalRequired()) {
+        if (!$require_approval) {
             if ($request->isSlotStillAvailable()) {
                 $request->approve(0, '');
             } else {

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -33,6 +33,7 @@
 
 namespace GlpiPlugin\Advancedforms\Model\Destination;
 
+use Glpi\Form\Answer;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\AnswersSet;
@@ -92,6 +93,7 @@ final class PreReservationField extends AbstractConfigField
         foreach (PreReservationFieldStrategy::cases() as $strategy) {
             $values[$strategy->value] = $strategy->getLabel();
         }
+
         return $values;
     }
 
@@ -163,7 +165,7 @@ final class PreReservationField extends AbstractConfigField
         }
 
         $question_answer = $answers_set->getAnswerByQuestionId($question_id);
-        if ($question_answer === null) {
+        if (!$question_answer instanceof Answer) {
             // The question was left unanswered (or skipped): nothing to do.
             return;
         }

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -1,0 +1,221 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\Destination;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractConfigField;
+use Glpi\Form\Destination\CommonITILField\Category;
+use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Form;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use InvalidArgumentException;
+use Override;
+use Ticket;
+
+/**
+ * Destination config field allowing a form to automatically create a
+ * `TicketReservationRequest` from the answer of a `ReservationQuestion` once
+ * the destination `Ticket` has been created.
+ */
+final class PreReservationField extends AbstractConfigField
+{
+    #[Override]
+    public function getLabel(): string
+    {
+        return __('Pre-reservation', 'advancedforms');
+    }
+
+    #[Override]
+    public function getConfigClass(): string
+    {
+        return PreReservationFieldConfig::class;
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 1000;
+    }
+
+    #[Override]
+    public function getCategory(): Category
+    {
+        return Category::PROPERTIES;
+    }
+
+    #[Override]
+    public function getDefaultConfig(Form $form): PreReservationFieldConfig
+    {
+        return new PreReservationFieldConfig(PreReservationFieldStrategy::NO_PRERESERVATION);
+    }
+
+    /** @return array<string, string> */
+    #[Override]
+    public function getStrategiesForDropdown(): array
+    {
+        $values = [];
+        foreach (PreReservationFieldStrategy::cases() as $strategy) {
+            $values[$strategy->value] = $strategy->getLabel();
+        }
+        return $values;
+    }
+
+    /** @param array<string, mixed> $display_options */
+    #[Override]
+    public function renderConfigForm(
+        Form $form,
+        FormDestination $destination,
+        JsonFieldInterface $config,
+        string $input_name,
+        array $display_options,
+    ): string {
+        if (!$config instanceof PreReservationFieldConfig) {
+            throw new InvalidArgumentException("Unexpected config class");
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render('@advancedforms/destination/prereservation_config_field.html.twig', [
+            // Possible configuration constant that will be used to hide/show additional fields
+            'CONFIG_FROM_SPECIFIC_QUESTION' => PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION->value,
+
+            // General display options
+            'options' => $display_options,
+
+            // Additional config displayed only for the FROM_SPECIFIC_QUESTION strategy
+            'question_extra_field' => [
+                'empty_label'     => __("Select a question...", 'advancedforms'),
+                'value'           => $config->getQuestionId(),
+                'input_name'      => $input_name . "[" . PreReservationFieldConfig::QUESTION_ID . "]",
+                'possible_values' => $this->getReservationQuestionsValuesForDropdown($form),
+            ],
+            'require_approval_extra_field' => [
+                'value'      => $config->isApprovalRequired(),
+                'input_name' => $input_name . "[" . PreReservationFieldConfig::REQUIRE_APPROVAL . "]",
+            ],
+        ]);
+    }
+
+    #[Override]
+    public function applyConfiguratedValueAfterDestinationCreation(
+        FormDestination $destination,
+        JsonFieldInterface $config,
+        AnswersSet $answers_set,
+        array $created_objects,
+    ): void {
+        if (!$config instanceof PreReservationFieldConfig) {
+            return;
+        }
+
+        // Only one strategy is allowed
+        $strategy = current($config->getStrategies());
+        if ($strategy !== PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION) {
+            // Nothing to do: no pre-reservation was requested for this destination.
+            return;
+        }
+
+        $question_id = $config->getQuestionId();
+        if ($question_id === null) {
+            return;
+        }
+
+        // `$created_objects` maps each destination's id to the items it
+        // created (see `DestinationFieldInterface::applyConfiguratedValueAfterDestinationCreation()`
+        // and `AnswersHandler::createDestinations()`), it is not a flat list.
+        $destination_items = $created_objects[$destination->getID()] ?? [];
+        $ticket = $destination_items[0] ?? null;
+        if (!$ticket instanceof Ticket) {
+            return;
+        }
+
+        $question_answer = $answers_set->getAnswerByQuestionId($question_id);
+        if ($question_answer === null) {
+            // The question was left unanswered (or skipped): nothing to do.
+            return;
+        }
+
+        $raw_answer = $question_answer->getRawAnswer();
+        if (!is_array($raw_answer)) {
+            return;
+        }
+
+        try {
+            // @phpstan-ignore argument.type (the exact shape is validated at runtime by fromArray() itself)
+            $answer = ReservationQuestionAnswer::fromArray($raw_answer);
+        } catch (InvalidArgumentException) {
+            // Incomplete/invalid answer: do not block the ticket creation.
+            return;
+        }
+
+        $request = new TicketReservationRequest();
+        $request_id = $request->add([
+            'tickets_id'          => $ticket->getID(),
+            'reservationitems_id' => $answer->getReservationItemsId(),
+            // @phpstan-ignore cast.int (CommonDBTM::$fields is not generically typed)
+            'users_id'            => (int) ($answers_set->fields['users_id'] ?? 0),
+            'begin'               => $answer->getBegin(),
+            'end'                 => $answer->getEnd(),
+            'status'              => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        if (!$request_id) {
+            return;
+        }
+
+        if (!$config->isApprovalRequired()) {
+            if ($request->isSlotStillAvailable()) {
+                $request->approve(0, '');
+            } else {
+                $request->markUnavailable();
+            }
+        }
+    }
+
+    /** @return array<int, string> */
+    private function getReservationQuestionsValuesForDropdown(Form $form): array
+    {
+        $values = [];
+        $questions = $form->getQuestionsByType(ReservationQuestion::class);
+
+        foreach ($questions as $question) {
+            // @phpstan-ignore cast.string (CommonDBTM::$fields is not generically typed)
+            $values[$question->getId()] = (string) $question->fields['name'];
+        }
+
+        return $values;
+    }
+}

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -48,11 +48,7 @@ use InvalidArgumentException;
 use Override;
 use Ticket;
 
-/**
- * Destination config field allowing a form to automatically create a
- * `TicketReservationRequest` from the answer of a `ReservationQuestion` once
- * the destination `Ticket` has been created.
- */
+/** Turns a ReservationQuestion answer into a TicketReservationRequest once the destination Ticket is created. */
 final class PreReservationField extends AbstractConfigField
 {
     #[Override]
@@ -112,13 +108,10 @@ final class PreReservationField extends AbstractConfigField
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render('@advancedforms/destination/prereservation_config_field.html.twig', [
-            // Possible configuration constant that will be used to hide/show additional fields
             'CONFIG_FROM_SPECIFIC_QUESTION' => PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION->value,
 
-            // General display options
             'options' => $display_options,
 
-            // Additional config displayed only for the FROM_SPECIFIC_QUESTION strategy
             'question_extra_field' => [
                 'empty_label'     => __("Select a question...", 'advancedforms'),
                 'value'           => $config->getQuestionId(),
@@ -143,10 +136,8 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
-        // Only one strategy is allowed
         $strategy = current($config->getStrategies());
         if ($strategy !== PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION) {
-            // Nothing to do: no pre-reservation was requested for this destination.
             return;
         }
 
@@ -155,9 +146,6 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
-        // `$created_objects` maps each destination's id to the items it
-        // created (see `DestinationFieldInterface::applyConfiguratedValueAfterDestinationCreation()`
-        // and `AnswersHandler::createDestinations()`), it is not a flat list.
         $destination_items = $created_objects[$destination->getID()] ?? [];
         $ticket = $destination_items[0] ?? null;
         if (!$ticket instanceof Ticket) {
@@ -166,7 +154,6 @@ final class PreReservationField extends AbstractConfigField
 
         $question_answer = $answers_set->getAnswerByQuestionId($question_id);
         if (!$question_answer instanceof Answer) {
-            // The question was left unanswered (or skipped): nothing to do.
             return;
         }
 
@@ -178,7 +165,6 @@ final class PreReservationField extends AbstractConfigField
         try {
             $answer = ReservationQuestionAnswer::fromArray($raw_answer);
         } catch (InvalidArgumentException) {
-            // Incomplete/invalid answer: do not block the ticket creation.
             return;
         }
 
@@ -195,16 +181,6 @@ final class PreReservationField extends AbstractConfigField
         ];
 
         if (!$require_approval) {
-            // In direct/no-approval mode, the WAITING status set above is
-            // only a transient step before immediately transitioning this
-            // request to its real final state below (ACCEPTED/CANCELED),
-            // which each raise their own distinct notification event. The
-            // request never actually waits for approval, so the "please wait
-            // for approval" notification must be suppressed for this insert.
-            // (The key must only be present when disabling: `isset()` is what
-            // `TicketReservationRequest::post_addItem()` checks, and it is
-            // `true` even for an explicit `false` value, matching the
-            // `_disablenotif` convention used throughout GLPI core.)
             $add_input['_disablenotif'] = true;
         }
 

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -33,13 +33,17 @@
 
 namespace GlpiPlugin\Advancedforms\Model\Destination;
 
-use Glpi\Form\Answer;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Answer;
 use Glpi\Form\AnswersSet;
+use Glpi\Form\Destination\AbstractCommonITILFormDestination;
 use Glpi\Form\Destination\AbstractConfigField;
 use Glpi\Form\Destination\CommonITILField\Category;
 use Glpi\Form\Destination\FormDestination;
+use Glpi\Form\Export\Context\DatabaseMapper;
+use Glpi\Form\Export\Serializer\DynamicExportDataField;
+use Glpi\Form\Export\Specification\DataRequirementSpecification;
 use Glpi\Form\Form;
 use Glpi\Form\Question;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
@@ -47,14 +51,16 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionConfig;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use InvalidArgumentException;
+use ITILFollowup;
 use Override;
 use ReservationItem;
 use Safe\Exceptions\JsonException;
+use Session;
 use Ticket;
 
 use function Safe\json_decode;
 
-/** Turns a ReservationQuestion answer into a TicketReservationRequest once the destination Ticket is created. */
+/** Turns ReservationQuestion answers into TicketReservationRequest(s) once the destination Ticket is created. */
 final class PreReservationField extends AbstractConfigField
 {
     #[Override]
@@ -72,19 +78,22 @@ final class PreReservationField extends AbstractConfigField
     #[Override]
     public function getWeight(): int
     {
-        return 1000;
+        return 40;
     }
 
     #[Override]
     public function getCategory(): Category
     {
-        return Category::PROPERTIES;
+        return Category::TIMELINE;
     }
 
     #[Override]
     public function getDefaultConfig(Form $form): PreReservationFieldConfig
     {
-        return new PreReservationFieldConfig(PreReservationFieldStrategy::NO_PRERESERVATION);
+        // A question of this type is a strong signal that the destination
+        // should use it; default to the safest question-backed strategy
+        // rather than silently doing nothing.
+        return new PreReservationFieldConfig(PreReservationFieldStrategy::LAST_VALID_ANSWER);
     }
 
     /** @return array<string, string> */
@@ -114,14 +123,16 @@ final class PreReservationField extends AbstractConfigField
 
         $twig = TemplateRenderer::getInstance();
         return $twig->render('@advancedforms/destination/prereservation_config_field.html.twig', [
-            'CONFIG_FROM_SPECIFIC_QUESTION' => PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION->value,
+            'CONFIG_SPECIFIC_ANSWER' => PreReservationFieldStrategy::SPECIFIC_ANSWER->value,
+            'CONFIG_LAST_VALID_ANSWER' => PreReservationFieldStrategy::LAST_VALID_ANSWER->value,
+            'CONFIG_ALL_VALID_ANSWERS' => PreReservationFieldStrategy::ALL_VALID_ANSWERS->value,
 
             'options' => $display_options,
 
             'question_extra_field' => [
                 'empty_label'     => __("Select a question...", 'advancedforms'),
-                'value'           => $config->getQuestionId(),
-                'input_name'      => $input_name . "[" . PreReservationFieldConfig::QUESTION_ID . "]",
+                'value'           => $config->getSpecificQuestionId(),
+                'input_name'      => $input_name . "[" . PreReservationFieldConfig::SPECIFIC_QUESTION_ID . "]",
                 'possible_values' => $this->getReservationQuestionsValuesForDropdown($form),
             ],
             'require_approval_extra_field' => [
@@ -142,13 +153,10 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
-        $strategy = current($config->getStrategies());
-        if ($strategy !== PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION) {
-            return;
-        }
-
-        $question_id = $config->getQuestionId();
-        if ($question_id === null) {
+        // Only one strategy is allowed.
+        $strategy = $config->getStrategies()[0];
+        $answers = $strategy->getReservationAnswers($config, $answers_set);
+        if ($answers === []) {
             return;
         }
 
@@ -158,48 +166,68 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
-        $question_answer = $answers_set->getAnswerByQuestionId($question_id);
-        if (!$question_answer instanceof Answer) {
-            return;
-        }
-
-        $raw_answer = $question_answer->getRawAnswer();
-        if (!is_array($raw_answer)) {
-            return;
-        }
-
-        try {
-            $answer = ReservationQuestionAnswer::fromArray($raw_answer);
-        } catch (InvalidArgumentException) {
-            return;
-        }
-
-        // Reject incoherent timeframes (end before begin, etc.).
-        if (!$answer->isValidRange()) {
-            return;
-        }
-
-        // A pre-reservation without a real requester makes no sense.
+        // A pre-reservation without a real requester makes no sense (e.g. anonymous form access).
         // @phpstan-ignore cast.int (CommonDBTM::$fields is not generically typed)
         $users_id = (int) ($answers_set->fields['users_id'] ?? 0);
         if ($users_id <= 0) {
-            return;
-        }
-
-        // The item id comes from a client-controlled hidden field: re-check it is
-        // an active reservable item allowed by the question configuration.
-        if (!$this->isAnswerItemAllowed($answer->getReservationItemsId(), $question_id)) {
+            $this->logAndNotifyFailure(
+                $ticket,
+                sprintf('Pre-reservation not created for ticket #%d: no identifiable requester.', $ticket->getID()),
+                __('The pre-reservation could not be created: no identifiable requester.', 'advancedforms'),
+            );
             return;
         }
 
         $require_approval = $config->isApprovalRequired();
 
+        foreach ($answers as $answer) {
+            $this->createReservationRequest($ticket, $answer, $users_id, $require_approval);
+        }
+    }
+
+    private function createReservationRequest(
+        Ticket $ticket,
+        Answer $answer,
+        int $users_id,
+        bool $require_approval,
+    ): void {
+        $raw_answer = $answer->getRawAnswer();
+        if (!is_array($raw_answer)) {
+            return;
+        }
+
+        try {
+            $parsed = ReservationQuestionAnswer::fromArray($raw_answer);
+        } catch (InvalidArgumentException) {
+            return;
+        }
+
+        // Reject incoherent timeframes (end before begin, etc.).
+        if (!$parsed->isValidRange()) {
+            return;
+        }
+
+        // The item id comes from a client-controlled hidden field: re-check it is
+        // an active reservable item, in a visible entity, allowed by the question configuration.
+        if (!$this->isAnswerItemAllowed($parsed->getReservationItemsId(), $answer->getQuestionId())) {
+            $this->logAndNotifyFailure(
+                $ticket,
+                sprintf(
+                    'Pre-reservation not created for ticket #%d: item #%d is not allowed.',
+                    $ticket->getID(),
+                    $parsed->getReservationItemsId(),
+                ),
+                __('The pre-reservation could not be created: the selected item is not allowed.', 'advancedforms'),
+            );
+            return;
+        }
+
         $add_input = [
             'tickets_id'          => $ticket->getID(),
-            'reservationitems_id' => $answer->getReservationItemsId(),
+            'reservationitems_id' => $parsed->getReservationItemsId(),
             'users_id'            => $users_id,
-            'begin'               => $answer->getBegin(),
-            'end'                 => $answer->getEnd(),
+            'begin'               => $parsed->getBegin(),
+            'end'                 => $parsed->getEnd(),
             'status'              => TicketReservationRequest::STATUS_WAITING,
         ];
 
@@ -211,20 +239,40 @@ final class PreReservationField extends AbstractConfigField
         $request_id = $request->add($add_input);
 
         if (!$request_id) {
+            trigger_error(
+                sprintf('Failed to create the pre-reservation request for ticket #%d.', $ticket->getID()),
+                E_USER_WARNING,
+            );
             return;
         }
 
         if (!$require_approval) {
-            if ($request->isSlotStillAvailable()) {
-                $request->approve(0, '');
-            } else {
+            // Evaluate availability once: approve() itself creates the Reservation,
+            // which would make a second isSlotStillAvailable() call return false.
+            $slot_was_available = $request->isSlotStillAvailable();
+            if (!$slot_was_available || !$request->approve(0, '')) {
                 $request->markUnavailable();
             }
         }
     }
 
+    /** Logs the failure and adds a visible followup so the technician isn't left guessing why no reservation exists. */
+    private function logAndNotifyFailure(Ticket $ticket, string $log_message, string $followup_message): void
+    {
+        trigger_error($log_message, E_USER_WARNING);
+
+        $followup = new ITILFollowup();
+        $followup->add([
+            'itemtype'      => Ticket::class,
+            'items_id'      => $ticket->getID(),
+            'content'       => $followup_message,
+            '_disablenotif' => true,
+        ]);
+    }
+
     /**
-     * Whether the answered item is a still-active reservable item that the question accepts.
+     * Whether the answered item is a still-active reservable item, in a visible
+     * entity, that the question accepts.
      * The item id is client-controlled, so it must never be trusted as-is.
      */
     private function isAnswerItemAllowed(int $reservationitems_id, int $question_id): bool
@@ -240,6 +288,12 @@ final class PreReservationField extends AbstractConfigField
 
         $is_active = $reservation_item->fields['is_active'] ?? 0;
         if (!is_numeric($is_active) || (int) $is_active !== 1) {
+            return false;
+        }
+
+        $entities_id = $reservation_item->fields['entities_id'] ?? -1;
+        $is_recursive = $reservation_item->fields['is_recursive'] ?? 0;
+        if (!is_numeric($entities_id) || !Session::haveAccessToEntity((int) $entities_id, (bool) $is_recursive)) {
             return false;
         }
 
@@ -297,5 +351,52 @@ final class PreReservationField extends AbstractConfigField
         }
 
         return $values;
+    }
+
+    /** @param array<string, mixed> $config */
+    #[Override]
+    public function exportDynamicConfig(
+        array $config,
+        AbstractCommonITILFormDestination $destination,
+    ): DynamicExportDataField {
+        $fallback = parent::exportDynamicConfig($config, $destination);
+
+        $question_id = $config[PreReservationFieldConfig::SPECIFIC_QUESTION_ID] ?? null;
+        if (!is_int($question_id)) {
+            return $fallback;
+        }
+
+        $question = Question::getById($question_id);
+        if (!$question instanceof Question) {
+            $config[PreReservationFieldConfig::SPECIFIC_QUESTION_ID] = null;
+            return new DynamicExportDataField($config, []);
+        }
+
+        // Insert question name and requirement.
+        $requirement = DataRequirementSpecification::fromItem($question);
+        $config[PreReservationFieldConfig::SPECIFIC_QUESTION_ID] = $requirement->name;
+
+        return new DynamicExportDataField($config, [$requirement]);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public static function prepareDynamicConfigDataForImport(
+        array $config,
+        AbstractCommonITILFormDestination $destination,
+        DatabaseMapper $mapper,
+    ): array {
+        $specific_question_name = $config[PreReservationFieldConfig::SPECIFIC_QUESTION_ID] ?? null;
+        if (is_string($specific_question_name)) {
+            $config[PreReservationFieldConfig::SPECIFIC_QUESTION_ID] = $mapper->getItemId(
+                Question::class,
+                $specific_question_name,
+            );
+        }
+
+        return $config;
     }
 }

--- a/src/Model/Destination/PreReservationField.php
+++ b/src/Model/Destination/PreReservationField.php
@@ -41,12 +41,18 @@ use Glpi\Form\Destination\AbstractConfigField;
 use Glpi\Form\Destination\CommonITILField\Category;
 use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Form;
+use Glpi\Form\Question;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionConfig;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use InvalidArgumentException;
 use Override;
+use ReservationItem;
+use Safe\Exceptions\JsonException;
 use Ticket;
+
+use function Safe\json_decode;
 
 /** Turns a ReservationQuestion answer into a TicketReservationRequest once the destination Ticket is created. */
 final class PreReservationField extends AbstractConfigField
@@ -168,13 +174,30 @@ final class PreReservationField extends AbstractConfigField
             return;
         }
 
+        // Reject incoherent timeframes (end before begin, etc.).
+        if (!$answer->isValidRange()) {
+            return;
+        }
+
+        // A pre-reservation without a real requester makes no sense.
+        // @phpstan-ignore cast.int (CommonDBTM::$fields is not generically typed)
+        $users_id = (int) ($answers_set->fields['users_id'] ?? 0);
+        if ($users_id <= 0) {
+            return;
+        }
+
+        // The item id comes from a client-controlled hidden field: re-check it is
+        // an active reservable item allowed by the question configuration.
+        if (!$this->isAnswerItemAllowed($answer->getReservationItemsId(), $question_id)) {
+            return;
+        }
+
         $require_approval = $config->isApprovalRequired();
 
         $add_input = [
             'tickets_id'          => $ticket->getID(),
             'reservationitems_id' => $answer->getReservationItemsId(),
-            // @phpstan-ignore cast.int (CommonDBTM::$fields is not generically typed)
-            'users_id'            => (int) ($answers_set->fields['users_id'] ?? 0),
+            'users_id'            => $users_id,
             'begin'               => $answer->getBegin(),
             'end'                 => $answer->getEnd(),
             'status'              => TicketReservationRequest::STATUS_WAITING,
@@ -198,6 +221,68 @@ final class PreReservationField extends AbstractConfigField
                 $request->markUnavailable();
             }
         }
+    }
+
+    /**
+     * Whether the answered item is a still-active reservable item that the question accepts.
+     * The item id is client-controlled, so it must never be trusted as-is.
+     */
+    private function isAnswerItemAllowed(int $reservationitems_id, int $question_id): bool
+    {
+        if ($reservationitems_id <= 0) {
+            return false;
+        }
+
+        $reservation_item = new ReservationItem();
+        if (!$reservation_item->getFromDB($reservationitems_id)) {
+            return false;
+        }
+
+        $is_active = $reservation_item->fields['is_active'] ?? 0;
+        if (!is_numeric($is_active) || (int) $is_active !== 1) {
+            return false;
+        }
+
+        $allowed_itemtypes = $this->getConfiguredAllowedItemtypes($question_id);
+        if ($allowed_itemtypes === []) {
+            // Question accepts any reservable item; being active is enough.
+            return true;
+        }
+
+        $itemtype = $reservation_item->fields['itemtype'] ?? '';
+
+        return is_string($itemtype) && in_array($itemtype, $allowed_itemtypes, true);
+    }
+
+    /**
+     * Itemtypes explicitly whitelisted on the question, or [] when unrestricted.
+     *
+     * @return array<string>
+     */
+    private function getConfiguredAllowedItemtypes(int $question_id): array
+    {
+        $question = Question::getById($question_id);
+        if (!$question instanceof Question) {
+            return [];
+        }
+
+        $extra_data = $question->fields['extra_data'] ?? null;
+        if (!is_string($extra_data) || $extra_data === '') {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($extra_data, associative: true);
+        } catch (JsonException) {
+            return [];
+        }
+
+        if (!is_array($decoded)) {
+            return [];
+        }
+
+        /** @var array{allowed_itemtypes?: array<string>} $decoded */
+        return ReservationQuestionConfig::jsonDeserialize($decoded)->getAllowedItemtypes();
     }
 
     /** @return array<int, string> */

--- a/src/Model/Destination/PreReservationFieldConfig.php
+++ b/src/Model/Destination/PreReservationFieldConfig.php
@@ -43,7 +43,9 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
 {
     // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
+
     public const QUESTION_ID = 'question_id';
+
     public const REQUIRE_APPROVAL = 'require_approval';
 
     public function __construct(

--- a/src/Model/Destination/PreReservationFieldConfig.php
+++ b/src/Model/Destination/PreReservationFieldConfig.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\Destination;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
+use Glpi\Form\Destination\HasFieldWithQuestionId;
+use Override;
+
+#[HasFieldWithQuestionId(self::QUESTION_ID)]
+final readonly class PreReservationFieldConfig implements JsonFieldInterface, ConfigFieldWithStrategiesInterface
+{
+    // Unique reference to hardcoded names used for serialization and forms input names
+    public const STRATEGY = 'strategy';
+    public const QUESTION_ID = 'question_id';
+    public const REQUIRE_APPROVAL = 'require_approval';
+
+    public function __construct(
+        private PreReservationFieldStrategy $strategy,
+        private ?int $question_id = null,
+        private bool $require_approval = true,
+    ) {}
+
+    /**
+     * @param array{
+     *      strategy?: string,
+     *      question_id?: ?int,
+     *      require_approval?: bool
+     * } $data
+     */
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        $strategy = PreReservationFieldStrategy::tryFrom($data[self::STRATEGY] ?? "");
+        if ($strategy === null) {
+            $strategy = PreReservationFieldStrategy::NO_PRERESERVATION;
+        }
+
+        return new self(
+            strategy: $strategy,
+            question_id: $data[self::QUESTION_ID] ?? null,
+            require_approval: $data[self::REQUIRE_APPROVAL] ?? true,
+        );
+    }
+
+    /**
+     * @return array{
+     *      strategy: string,
+     *      question_id: ?int,
+     *      require_approval: bool
+     * }
+     */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::STRATEGY => $this->strategy->value,
+            self::QUESTION_ID => $this->question_id,
+            self::REQUIRE_APPROVAL => $this->require_approval,
+        ];
+    }
+
+    #[Override]
+    public static function getStrategiesInputName(): string
+    {
+        return self::STRATEGY;
+    }
+
+    /**
+     * @return array<PreReservationFieldStrategy>
+     */
+    #[Override]
+    public function getStrategies(): array
+    {
+        return [$this->strategy];
+    }
+
+    public function getQuestionId(): ?int
+    {
+        return $this->question_id;
+    }
+
+    public function isApprovalRequired(): bool
+    {
+        return $this->require_approval;
+    }
+}

--- a/src/Model/Destination/PreReservationFieldConfig.php
+++ b/src/Model/Destination/PreReservationFieldConfig.php
@@ -41,7 +41,6 @@ use Override;
 #[HasFieldWithQuestionId(self::QUESTION_ID)]
 final readonly class PreReservationFieldConfig implements JsonFieldInterface, ConfigFieldWithStrategiesInterface
 {
-    // Unique reference to hardcoded names used for serialization and forms input names
     public const STRATEGY = 'strategy';
 
     public const QUESTION_ID = 'question_id';
@@ -99,9 +98,7 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
         return self::STRATEGY;
     }
 
-    /**
-     * @return array<PreReservationFieldStrategy>
-     */
+    /** @return array<PreReservationFieldStrategy> */
     #[Override]
     public function getStrategies(): array
     {

--- a/src/Model/Destination/PreReservationFieldConfig.php
+++ b/src/Model/Destination/PreReservationFieldConfig.php
@@ -38,25 +38,25 @@ use Glpi\Form\Destination\ConfigFieldWithStrategiesInterface;
 use Glpi\Form\Destination\HasFieldWithQuestionId;
 use Override;
 
-#[HasFieldWithQuestionId(self::QUESTION_ID)]
+#[HasFieldWithQuestionId(self::SPECIFIC_QUESTION_ID)]
 final readonly class PreReservationFieldConfig implements JsonFieldInterface, ConfigFieldWithStrategiesInterface
 {
     public const STRATEGY = 'strategy';
 
-    public const QUESTION_ID = 'question_id';
+    public const SPECIFIC_QUESTION_ID = 'specific_question_id';
 
     public const REQUIRE_APPROVAL = 'require_approval';
 
     public function __construct(
         private PreReservationFieldStrategy $strategy,
-        private ?int $question_id = null,
+        private ?int $specific_question_id = null,
         private bool $require_approval = true,
     ) {}
 
     /**
      * @param array{
      *      strategy?: string,
-     *      question_id?: ?int,
+     *      specific_question_id?: ?int,
      *      require_approval?: bool
      * } $data
      */
@@ -70,7 +70,7 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
 
         return new self(
             strategy: $strategy,
-            question_id: $data[self::QUESTION_ID] ?? null,
+            specific_question_id: $data[self::SPECIFIC_QUESTION_ID] ?? null,
             require_approval: $data[self::REQUIRE_APPROVAL] ?? true,
         );
     }
@@ -78,7 +78,7 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
     /**
      * @return array{
      *      strategy: string,
-     *      question_id: ?int,
+     *      specific_question_id: ?int,
      *      require_approval: bool
      * }
      */
@@ -87,7 +87,7 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
     {
         return [
             self::STRATEGY => $this->strategy->value,
-            self::QUESTION_ID => $this->question_id,
+            self::SPECIFIC_QUESTION_ID => $this->specific_question_id,
             self::REQUIRE_APPROVAL => $this->require_approval,
         ];
     }
@@ -105,9 +105,9 @@ final readonly class PreReservationFieldConfig implements JsonFieldInterface, Co
         return [$this->strategy];
     }
 
-    public function getQuestionId(): ?int
+    public function getSpecificQuestionId(): ?int
     {
-        return $this->question_id;
+        return $this->specific_question_id;
     }
 
     public function isApprovalRequired(): bool

--- a/src/Model/Destination/PreReservationFieldStrategy.php
+++ b/src/Model/Destination/PreReservationFieldStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\Destination;
+
+enum PreReservationFieldStrategy: string
+{
+    case NO_PRERESERVATION = 'no_prereservation';
+    case FROM_SPECIFIC_QUESTION = 'from_specific_question';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::NO_PRERESERVATION => __('No pre-reservation', 'advancedforms'),
+            self::FROM_SPECIFIC_QUESTION => __('Pre-reservation: answer from a specific question', 'advancedforms'),
+        };
+    }
+}

--- a/src/Model/Destination/PreReservationFieldStrategy.php
+++ b/src/Model/Destination/PreReservationFieldStrategy.php
@@ -33,16 +33,101 @@
 
 namespace GlpiPlugin\Advancedforms\Model\Destination;
 
+use Glpi\Form\Answer;
+use Glpi\Form\AnswersSet;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;
+use InvalidArgumentException;
+
 enum PreReservationFieldStrategy: string
 {
     case NO_PRERESERVATION = 'no_prereservation';
-    case FROM_SPECIFIC_QUESTION = 'from_specific_question';
+    case SPECIFIC_ANSWER = 'specific_answer';
+    case LAST_VALID_ANSWER = 'last_valid_answer';
+    case ALL_VALID_ANSWERS = 'all_valid_answers';
 
     public function getLabel(): string
     {
         return match ($this) {
             self::NO_PRERESERVATION => __('No pre-reservation', 'advancedforms'),
-            self::FROM_SPECIFIC_QUESTION => __('Pre-reservation: answer from a specific question', 'advancedforms'),
+            self::SPECIFIC_ANSWER => __('Answer from a specific question', 'advancedforms'),
+            self::LAST_VALID_ANSWER => __('Answer to last "Material reservation" question', 'advancedforms'),
+            self::ALL_VALID_ANSWERS => __('All valid "Material reservation" answers', 'advancedforms'),
         };
+    }
+
+    /**
+     * Resolves the answers this strategy should turn into pre-reservations.
+     * Only syntactically valid answers (parseable, coherent timeframe) are
+     * returned; per-item authorization is checked separately by the caller.
+     *
+     * @return array<Answer>
+     */
+    public function getReservationAnswers(
+        PreReservationFieldConfig $config,
+        AnswersSet $answers_set,
+    ): array {
+        return match ($this) {
+            self::NO_PRERESERVATION => [],
+            self::SPECIFIC_ANSWER => $this->getAnswerForSpecificQuestion(
+                $config->getSpecificQuestionId(),
+                $answers_set,
+            ),
+            self::LAST_VALID_ANSWER => $this->getLastValidAnswer($answers_set),
+            self::ALL_VALID_ANSWERS => $this->getValidAnswers($answers_set),
+        };
+    }
+
+    /** @return array<Answer> */
+    private function getAnswerForSpecificQuestion(
+        ?int $question_id,
+        AnswersSet $answers_set,
+    ): array {
+        if ($question_id === null) {
+            return [];
+        }
+
+        $answer = $answers_set->getAnswerByQuestionId($question_id);
+        if (!$answer instanceof Answer || !$this->isValidAnswer($answer)) {
+            return [];
+        }
+
+        return [$answer];
+    }
+
+    /** @return array<Answer> */
+    private function getLastValidAnswer(AnswersSet $answers_set): array
+    {
+        $valid_answers = $this->getValidAnswers($answers_set);
+        if ($valid_answers === []) {
+            return [];
+        }
+
+        return [end($valid_answers)];
+    }
+
+    /** @return array<Answer> */
+    private function getValidAnswers(AnswersSet $answers_set): array
+    {
+        return array_values(array_filter(
+            $answers_set->getAnswersByType(ReservationQuestion::class),
+            $this->isValidAnswer(...),
+        ));
+    }
+
+    private function isValidAnswer(Answer $answer): bool
+    {
+        $raw_answer = $answer->getRawAnswer();
+        if (!is_array($raw_answer)) {
+            return false;
+        }
+
+        try {
+            $parsed = ReservationQuestionAnswer::fromArray($raw_answer);
+        } catch (InvalidArgumentException) {
+            return false;
+        }
+
+        return $parsed->isValidRange();
     }
 }

--- a/src/Model/NotificationTargetTicketReservationRequest.php
+++ b/src/Model/NotificationTargetTicketReservationRequest.php
@@ -39,14 +39,7 @@ use NotificationTarget;
 use Override;
 use Ticket;
 
-/**
- * Notification target for `TicketReservationRequest`. Auto-discovered by
- * core (see `NotificationTarget::getInstanceClass()`) because it lives in
- * the same namespace as `TicketReservationRequest` and is named
- * `NotificationTarget<ShortClassName>`.
- *
- * @extends NotificationTarget<TicketReservationRequest>
- */
+/** @extends NotificationTarget<TicketReservationRequest> */
 final class NotificationTargetTicketReservationRequest extends NotificationTarget
 {
     #[Override]
@@ -63,12 +56,8 @@ final class NotificationTargetTicketReservationRequest extends NotificationTarge
     #[Override]
     public function addAdditionalTargets($event = ''): void
     {
-        // The original requester (the request's own `users_id`, not the
-        // validator) is always notified.
         $this->addTarget(Notification::AUTHOR, __('Requester'));
 
-        // Only notify the parent ticket's technician(s) when a new request
-        // is created: they are the ones expected to approve/refuse it.
         if ($event === 'reservation_request_created') {
             $this->addTarget(Notification::ITEM_TECH_IN_CHARGE, __('Technician in charge'));
             $this->addTarget(Notification::ITEM_TECH_GROUP_IN_CHARGE, __('Group in charge'));
@@ -114,11 +103,6 @@ final class NotificationTargetTicketReservationRequest extends NotificationTarge
     #[Override]
     public function getObjectItem($event = '')
     {
-        // Technician-in-charge related targets are resolved from
-        // `$this->target_object` (see `NotificationTarget::addUserByField()`),
-        // and technicians are attached to the parent `Ticket`, not to the
-        // `TicketReservationRequest` itself. Point `target_object` at the
-        // parent ticket so those targets resolve correctly.
         if ($this->obj instanceof TicketReservationRequest) {
             $tickets_id = $this->obj->fields['tickets_id'];
             $ticket = new Ticket();

--- a/src/Model/NotificationTargetTicketReservationRequest.php
+++ b/src/Model/NotificationTargetTicketReservationRequest.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model;
+
+use Html;
+use Notification;
+use NotificationTarget;
+use Override;
+use Ticket;
+
+/**
+ * Notification target for `TicketReservationRequest`. Auto-discovered by
+ * core (see `NotificationTarget::getInstanceClass()`) because it lives in
+ * the same namespace as `TicketReservationRequest` and is named
+ * `NotificationTarget<ShortClassName>`.
+ *
+ * @extends NotificationTarget<TicketReservationRequest>
+ */
+final class NotificationTargetTicketReservationRequest extends NotificationTarget
+{
+    #[Override]
+    public function getEvents(): array
+    {
+        return [
+            'reservation_request_created' => __('New pre-reservation request', 'advancedforms'),
+            'reservation_request_approved' => __('Pre-reservation request approved', 'advancedforms'),
+            'reservation_request_refused' => __('Pre-reservation request refused', 'advancedforms'),
+            'reservation_request_slot_unavailable' => __('Reservation slot no longer available', 'advancedforms'),
+        ];
+    }
+
+    #[Override]
+    public function addAdditionalTargets($event = ''): void
+    {
+        // The original requester (the request's own `users_id`, not the
+        // validator) is always notified.
+        $this->addTarget(Notification::AUTHOR, __('Requester'));
+
+        // Only notify the parent ticket's technician(s) when a new request
+        // is created: they are the ones expected to approve/refuse it.
+        if ($event === 'reservation_request_created') {
+            $this->addTarget(Notification::ITEM_TECH_IN_CHARGE, __('Technician in charge'));
+            $this->addTarget(Notification::ITEM_TECH_GROUP_IN_CHARGE, __('Group in charge'));
+        }
+    }
+
+    #[Override]
+    public function addDataForTemplate($event, $options = []): void
+    {
+        if (!$this->obj instanceof TicketReservationRequest) {
+            return;
+        }
+
+        $begin = $this->obj->getField('begin');
+        $end = $this->obj->getField('end');
+        $comment = $this->obj->getField('comment_validation');
+
+        $this->data['##reservationrequest.begin##'] = is_string($begin) ? (Html::convDateTime($begin) ?? '') : '';
+        $this->data['##reservationrequest.end##'] = is_string($end) ? (Html::convDateTime($end) ?? '') : '';
+        $this->data['##reservationrequest.comment##'] = is_string($comment) ? $comment : '';
+    }
+
+    #[Override]
+    public function getTags(): void
+    {
+        $tags = [
+            'reservationrequest.begin' => __('Reservation start date', 'advancedforms'),
+            'reservationrequest.end' => __('Reservation end date', 'advancedforms'),
+            'reservationrequest.comment' => __('Validation comment', 'advancedforms'),
+        ];
+
+        foreach ($tags as $tag => $label) {
+            $this->addTagToList([
+                'tag' => $tag,
+                'label' => $label,
+                'value' => true,
+            ]);
+        }
+
+        parent::getTags();
+    }
+
+    #[Override]
+    public function getObjectItem($event = '')
+    {
+        // Technician-in-charge related targets are resolved from
+        // `$this->target_object` (see `NotificationTarget::addUserByField()`),
+        // and technicians are attached to the parent `Ticket`, not to the
+        // `TicketReservationRequest` itself. Point `target_object` at the
+        // parent ticket so those targets resolve correctly.
+        if ($this->obj instanceof TicketReservationRequest) {
+            $tickets_id = $this->obj->fields['tickets_id'];
+            $ticket = new Ticket();
+            if (
+                (is_int($tickets_id) || is_string($tickets_id))
+                && $ticket->getFromDB($tickets_id)
+            ) {
+                $this->target_object[] = $ticket;
+                return;
+            }
+        }
+
+        parent::getObjectItem($event);
+    }
+}

--- a/src/Model/NotificationTargetTicketReservationRequest.php
+++ b/src/Model/NotificationTargetTicketReservationRequest.php
@@ -56,12 +56,9 @@ final class NotificationTargetTicketReservationRequest extends NotificationTarge
     #[Override]
     public function addAdditionalTargets($event = ''): void
     {
+        // Only the requester is offered: this itemtype carries no technician
+        // fields, so core item-technician targets cannot be resolved against it.
         $this->addTarget(Notification::AUTHOR, __('Requester'));
-
-        if ($event === 'reservation_request_created') {
-            $this->addTarget(Notification::ITEM_TECH_IN_CHARGE, __('Technician in charge'));
-            $this->addTarget(Notification::ITEM_TECH_GROUP_IN_CHARGE, __('Group in charge'));
-        }
     }
 
     #[Override]
@@ -75,18 +72,33 @@ final class NotificationTargetTicketReservationRequest extends NotificationTarge
         $end = $this->obj->getField('end');
         $comment = $this->obj->getField('comment_validation');
 
+        $this->data['##reservationrequest.action##'] = $this->getEvents()[$event] ?? '';
         $this->data['##reservationrequest.begin##'] = is_string($begin) ? (Html::convDateTime($begin) ?? '') : '';
         $this->data['##reservationrequest.end##'] = is_string($end) ? (Html::convDateTime($end) ?? '') : '';
         $this->data['##reservationrequest.comment##'] = is_string($comment) ? $comment : '';
+
+        $tickets_id = $this->obj->fields['tickets_id'] ?? 0;
+        $ticket = new Ticket();
+        if ((is_int($tickets_id) || is_string($tickets_id)) && $ticket->getFromDB($tickets_id)) {
+            $title = $ticket->fields['name'] ?? '';
+            $this->data['##reservationrequest.ticket_title##'] = is_string($title) ? $title : '';
+            $this->data['##reservationrequest.ticket_url##'] = $ticket->getFormURLWithID($ticket->getID());
+        } else {
+            $this->data['##reservationrequest.ticket_title##'] = '';
+            $this->data['##reservationrequest.ticket_url##'] = '';
+        }
     }
 
     #[Override]
     public function getTags(): void
     {
         $tags = [
+            'reservationrequest.action' => __('Notification reason', 'advancedforms'),
             'reservationrequest.begin' => __('Reservation start date', 'advancedforms'),
             'reservationrequest.end' => __('Reservation end date', 'advancedforms'),
             'reservationrequest.comment' => __('Validation comment', 'advancedforms'),
+            'reservationrequest.ticket_title' => __('Ticket title', 'advancedforms'),
+            'reservationrequest.ticket_url' => __('Ticket URL', 'advancedforms'),
         ];
 
         foreach ($tags as $tag => $label) {

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -1,0 +1,193 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\QuestionType;
+
+use Glpi\Application\View\TemplateRenderer;
+use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\AbstractQuestionType;
+use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
+use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use Override;
+
+use function Safe\json_decode;
+
+final class ReservationQuestion extends AbstractQuestionType implements ConfigurableItemInterface
+{
+    #[Override]
+    public function getCategory(): QuestionTypeCategoryInterface
+    {
+        return new AdvancedCategory();
+    }
+
+    #[Override]
+    public function getName(): string
+    {
+        return __('Material reservation', 'advancedforms');
+    }
+
+    #[Override]
+    public function getIcon(): string
+    {
+        return 'ti ti-calendar-event';
+    }
+
+    #[Override]
+    public function getWeight(): int
+    {
+        return 50;
+    }
+
+    #[Override]
+    public function getExtraDataConfigClass(): string
+    {
+        return ReservationQuestionConfig::class;
+    }
+
+    /** @param array<mixed> $input */
+    #[Override]
+    public function validateExtraDataInput(array $input): bool
+    {
+        // All fields of `ReservationQuestionConfig` are optional: an empty
+        // `allowed_itemtypes` list means "every reservable type is allowed".
+        return true;
+    }
+
+    #[Override]
+    public function renderAdministrationTemplate(Question|null $question): string
+    {
+        // Read extra config specific to this question type
+        $decoded_extra_data = [];
+        if ($question instanceof Question && is_string($question->fields['extra_data'])) {
+            $decoded_extra_data = json_decode(
+                $question->fields['extra_data'],
+                associative: true,
+            );
+
+            // Fallback to safe value
+            if (!is_array($decoded_extra_data)) {
+                $decoded_extra_data = [];
+            }
+        }
+
+        $config = $this->getExtraDataConfig($decoded_extra_data);
+        if (!$config instanceof JsonFieldInterface) {
+            $config = new ReservationQuestionConfig();
+        }
+
+        global $CFG_GLPI;
+        $reservation_types = [];
+        $configured_types = $CFG_GLPI['reservation_types'] ?? [];
+        if (is_array($configured_types)) {
+            foreach ($configured_types as $itemtype) {
+                if (is_string($itemtype) && class_exists($itemtype)) {
+                    $reservation_types[$itemtype] = $itemtype::getTypeName();
+                }
+            }
+        }
+
+        $twig = TemplateRenderer::getInstance();
+        return $twig->render(
+            '@advancedforms/editor/question_types/reservation_config.html.twig',
+            [
+                'question'          => $question,
+                'extra_data'        => $config,
+                'reservation_types' => $reservation_types,
+                'ALLOWED_ITEMTYPES' => ReservationQuestionConfig::ALLOWED_ITEMTYPES,
+            ],
+        );
+    }
+
+    #[Override]
+    public function renderEndUserTemplate(Question $question): string
+    {
+        // Minimal placeholder: the full Select2/Flatpickr widget is wired in
+        // a later task. For now, expose the raw wire format as empty hidden
+        // inputs so the end user answer processing pipeline can be tested.
+        return TemplateRenderer::getInstance()->renderFromStringTemplate(
+            <<<TWIG
+                <input type="hidden" name="{{ question.getEndUserInputName() }}[reservationitems_id]" value="" data-reservation-question-field="reservationitems_id">
+                <input type="hidden" name="{{ question.getEndUserInputName() }}[begin]" value="" data-reservation-question-field="begin">
+                <input type="hidden" name="{{ question.getEndUserInputName() }}[end]" value="" data-reservation-question-field="end">
+                TWIG,
+            ['question' => $question],
+        );
+    }
+
+    #[Override]
+    public function prepareEndUserAnswer(Question $question, mixed $answer): mixed
+    {
+        if (!is_array($answer)) {
+            return null;
+        }
+
+        return ReservationQuestionAnswer::fromArray($answer)->toArray();
+    }
+
+    #[Override]
+    public function formatRawAnswer(mixed $answer, Question $question): string
+    {
+        if (!is_array($answer)) {
+            return '';
+        }
+
+        $parsed = ReservationQuestionAnswer::fromArray($answer);
+
+        return sprintf('%s → %s', $parsed->getBegin(), $parsed->getEnd());
+    }
+
+    #[Override]
+    public static function getConfigKey(): string
+    {
+        return "enable_question_type_reservation";
+    }
+
+    #[Override]
+    public function getConfigTitle(): string
+    {
+        return __("Material reservation question type", 'advancedforms');
+    }
+
+    #[Override]
+    public function getConfigDescription(): string
+    {
+        return __("Allow users to reserve equipment from a form.", 'advancedforms');
+    }
+
+    #[Override]
+    public function getConfigIcon(): string
+    {
+        return $this->getIcon();
+    }
+}

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -80,15 +80,12 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
     #[Override]
     public function validateExtraDataInput(array $input): bool
     {
-        // All fields of `ReservationQuestionConfig` are optional: an empty
-        // `allowed_itemtypes` list means "every reservable type is allowed".
         return true;
     }
 
     #[Override]
     public function renderAdministrationTemplate(Question|null $question): string
     {
-        // Read extra config specific to this question type
         $decoded_extra_data = [];
         if ($question instanceof Question && is_string($question->fields['extra_data'])) {
             $decoded_extra_data = json_decode(
@@ -96,7 +93,6 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
                 associative: true,
             );
 
-            // Fallback to safe value
             if (!is_array($decoded_extra_data)) {
                 $decoded_extra_data = [];
             }
@@ -140,7 +136,6 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
                 associative: true,
             );
 
-            // Fallback to safe value
             if (!is_array($decoded_extra_data)) {
                 $decoded_extra_data = [];
             }
@@ -167,9 +162,6 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
         try {
             return ReservationQuestionAnswer::fromArray($answer)->toArray();
         } catch (InvalidArgumentException) {
-            // The question is optional (or was simply left untouched) and
-            // the widget's hidden inputs are empty: treat this the same as
-            // "not answered" instead of failing the whole form submission.
             return null;
         }
     }

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -35,12 +35,15 @@ namespace GlpiPlugin\Advancedforms\Model\QuestionType;
 
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\DBAL\JsonFieldInterface;
+use Glpi\Form\Destination\CommonITILField\Category;
+use Glpi\Form\Destination\FormDestination;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionType;
 use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
 use Glpi\Form\QuestionType\QuestionTypeValidationInterface;
 use Glpi\Form\ValidationResult;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use InvalidArgumentException;
 use Override;
@@ -121,10 +124,13 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
         return $twig->render(
             '@advancedforms/editor/question_types/reservation_config.html.twig',
             [
-                'question'          => $question,
-                'extra_data'        => $config,
-                'reservation_types' => $reservation_types,
-                'ALLOWED_ITEMTYPES' => ReservationQuestionConfig::ALLOWED_ITEMTYPES,
+                'question'                => $question,
+                'extra_data'              => $config,
+                'reservation_types'       => $reservation_types,
+                'ALLOWED_ITEMTYPES'       => ReservationQuestionConfig::ALLOWED_ITEMTYPES,
+                'destination_label'       => FormDestination::getTypeName(2),
+                'timeline_category_label' => Category::TIMELINE->getLabel(),
+                'pre_reservation_label'   => (new PreReservationField())->getLabel(),
             ],
         );
     }

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -39,6 +39,7 @@ use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionType;
 use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use InvalidArgumentException;
 use Override;
 
 use function Safe\json_decode;
@@ -132,17 +133,28 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
     #[Override]
     public function renderEndUserTemplate(Question $question): string
     {
-        // Minimal placeholder: the full Select2/Flatpickr widget is wired in
-        // a later task. For now, expose the raw wire format as empty hidden
-        // inputs so the end user answer processing pipeline can be tested.
-        return TemplateRenderer::getInstance()->renderFromStringTemplate(
-            <<<TWIG
-                <input type="hidden" name="{{ question.getEndUserInputName() }}[reservationitems_id]" value="" data-reservation-question-field="reservationitems_id">
-                <input type="hidden" name="{{ question.getEndUserInputName() }}[begin]" value="" data-reservation-question-field="begin">
-                <input type="hidden" name="{{ question.getEndUserInputName() }}[end]" value="" data-reservation-question-field="end">
-                TWIG,
-            ['question' => $question],
-        );
+        $decoded_extra_data = [];
+        if (is_string($question->fields['extra_data'])) {
+            $decoded_extra_data = json_decode(
+                $question->fields['extra_data'],
+                associative: true,
+            );
+
+            // Fallback to safe value
+            if (!is_array($decoded_extra_data)) {
+                $decoded_extra_data = [];
+            }
+        }
+
+        $config = $this->getExtraDataConfig($decoded_extra_data);
+        if (!$config instanceof ReservationQuestionConfig) {
+            $config = new ReservationQuestionConfig();
+        }
+
+        return TemplateRenderer::getInstance()->render('@advancedforms/reservation_question.html.twig', [
+            'input_name'        => $question->getEndUserInputName(),
+            'allowed_itemtypes' => $config->getAllowedItemtypes(),
+        ]);
     }
 
     #[Override]
@@ -152,7 +164,14 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
             return null;
         }
 
-        return ReservationQuestionAnswer::fromArray($answer)->toArray();
+        try {
+            return ReservationQuestionAnswer::fromArray($answer)->toArray();
+        } catch (InvalidArgumentException) {
+            // The question is optional (or was simply left untouched) and
+            // the widget's hidden inputs are empty: treat this the same as
+            // "not answered" instead of failing the whole form submission.
+            return null;
+        }
     }
 
     #[Override]
@@ -162,7 +181,11 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
             return '';
         }
 
-        $parsed = ReservationQuestionAnswer::fromArray($answer);
+        try {
+            $parsed = ReservationQuestionAnswer::fromArray($answer);
+        } catch (InvalidArgumentException) {
+            return '';
+        }
 
         return sprintf('%s → %s', $parsed->getBegin(), $parsed->getEnd());
     }

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -39,6 +39,7 @@ use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionType;
 use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use InvalidArgumentException;
 use Override;
 
@@ -160,10 +161,17 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
         }
 
         try {
-            return ReservationQuestionAnswer::fromArray($answer)->toArray();
+            $parsed = ReservationQuestionAnswer::fromArray($answer);
         } catch (InvalidArgumentException) {
             return null;
         }
+
+        // Drop incoherent timeframes (end before begin, etc.) rather than store them.
+        if (!$parsed->isValidRange()) {
+            return null;
+        }
+
+        return $parsed->toArray();
     }
 
     #[Override]
@@ -179,7 +187,12 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
             return '';
         }
 
-        return sprintf('%s → %s', $parsed->getBegin(), $parsed->getEnd());
+        $slot = sprintf('%s → %s', $parsed->getBegin(), $parsed->getEnd());
+        $equipment_name = TicketReservationRequest::getReservableItemName($parsed->getReservationItemsId());
+
+        return $equipment_name !== ''
+            ? sprintf('%s (%s)', $equipment_name, $slot)
+            : $slot;
     }
 
     #[Override]

--- a/src/Model/QuestionType/ReservationQuestion.php
+++ b/src/Model/QuestionType/ReservationQuestion.php
@@ -38,6 +38,8 @@ use Glpi\DBAL\JsonFieldInterface;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\AbstractQuestionType;
 use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
+use Glpi\Form\QuestionType\QuestionTypeValidationInterface;
+use Glpi\Form\ValidationResult;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use InvalidArgumentException;
@@ -45,7 +47,7 @@ use Override;
 
 use function Safe\json_decode;
 
-final class ReservationQuestion extends AbstractQuestionType implements ConfigurableItemInterface
+final class ReservationQuestion extends AbstractQuestionType implements ConfigurableItemInterface, QuestionTypeValidationInterface
 {
     #[Override]
     public function getCategory(): QuestionTypeCategoryInterface
@@ -172,6 +174,49 @@ final class ReservationQuestion extends AbstractQuestionType implements Configur
         }
 
         return $parsed->toArray();
+    }
+
+    /**
+     * Validates the end-user answer before submission so an item selected with
+     * missing or incoherent dates is reported instead of being silently dropped.
+     */
+    #[Override]
+    public function validateAnswer(Question $question, mixed $answer): ValidationResult
+    {
+        $result = new ValidationResult(true);
+
+        if (!is_array($answer)) {
+            $result->addError($question, __('Unexpected value', 'advancedforms'));
+            return $result;
+        }
+
+        $item = $answer['reservationitems_id'] ?? '';
+        $begin = $answer['begin'] ?? '';
+        $end = $answer['end'] ?? '';
+
+        // Nothing filled at all: treat as unanswered. The generic mandatory check
+        // never fires here (the answer is a non-empty array), so enforce it now.
+        if (in_array($item, ['', null], true) && in_array($begin, ['', null], true) && in_array($end, ['', null], true)) {
+            if (!empty($question->fields['is_mandatory'])) {
+                $result->addError($question, __('This field is mandatory'));
+            }
+
+            return $result;
+        }
+
+        // Partially filled or complete: the whole triple is required.
+        try {
+            $parsed = ReservationQuestionAnswer::fromArray($answer);
+        } catch (InvalidArgumentException) {
+            $result->addError($question, __('Please select an item and both a start and end date.', 'advancedforms'));
+            return $result;
+        }
+
+        if (!$parsed->isValidRange()) {
+            $result->addError($question, __('The end date must be after the start date.', 'advancedforms'));
+        }
+
+        return $result;
     }
 
     #[Override]

--- a/src/Model/QuestionType/ReservationQuestionAnswer.php
+++ b/src/Model/QuestionType/ReservationQuestionAnswer.php
@@ -34,6 +34,7 @@
 namespace GlpiPlugin\Advancedforms\Model\QuestionType;
 
 use InvalidArgumentException;
+use Safe\Exceptions\DatetimeException;
 
 use function Safe\strtotime;
 
@@ -96,6 +97,10 @@ final readonly class ReservationQuestionAnswer
 
     public function isValidRange(): bool
     {
-        return strtotime($this->begin) < strtotime($this->end);
+        try {
+            return strtotime($this->begin) < strtotime($this->end);
+        } catch (DatetimeException) {
+            return false;
+        }
     }
 }

--- a/src/Model/QuestionType/ReservationQuestionAnswer.php
+++ b/src/Model/QuestionType/ReservationQuestionAnswer.php
@@ -35,6 +35,8 @@ namespace GlpiPlugin\Advancedforms\Model\QuestionType;
 
 use InvalidArgumentException;
 
+use function Safe\strtotime;
+
 final readonly class ReservationQuestionAnswer
 {
     public function __construct(
@@ -44,11 +46,7 @@ final readonly class ReservationQuestionAnswer
     ) {}
 
     /**
-     * @param array{
-     *      reservationitems_id: int,
-     *      begin: string,
-     *      end: string
-     * } $data
+     * @param array<array-key, mixed> $data
      */
     public static function fromArray(array $data): self
     {
@@ -58,10 +56,18 @@ final readonly class ReservationQuestionAnswer
             }
         }
 
+        $reservationitems_id = $data['reservationitems_id'];
+        $begin = $data['begin'];
+        $end = $data['end'];
+
+        if (!is_numeric($reservationitems_id) || !is_string($begin) || !is_string($end)) {
+            throw new InvalidArgumentException('Invalid type for reservation answer data');
+        }
+
         return new self(
-            reservationitems_id: $data['reservationitems_id'],
-            begin: $data['begin'],
-            end: $data['end'],
+            reservationitems_id: (int) $reservationitems_id,
+            begin: $begin,
+            end: $end,
         );
     }
 

--- a/src/Model/QuestionType/ReservationQuestionAnswer.php
+++ b/src/Model/QuestionType/ReservationQuestionAnswer.php
@@ -45,9 +45,7 @@ final readonly class ReservationQuestionAnswer
         private string $end,
     ) {}
 
-    /**
-     * @param array<array-key, mixed> $data
-     */
+    /** @param array<array-key, mixed> $data */
     public static function fromArray(array $data): self
     {
         foreach (['reservationitems_id', 'begin', 'end'] as $key) {
@@ -71,13 +69,7 @@ final readonly class ReservationQuestionAnswer
         );
     }
 
-    /**
-     * @return array{
-     *      reservationitems_id: int,
-     *      begin: string,
-     *      end: string
-     * }
-     */
+    /** @return array{reservationitems_id: int, begin: string, end: string} */
     public function toArray(): array
     {
         return [

--- a/src/Model/QuestionType/ReservationQuestionAnswer.php
+++ b/src/Model/QuestionType/ReservationQuestionAnswer.php
@@ -54,14 +54,14 @@ final readonly class ReservationQuestionAnswer
     {
         foreach (['reservationitems_id', 'begin', 'end'] as $key) {
             if (!isset($data[$key]) || $data[$key] === '') {
-                throw new InvalidArgumentException("Missing or empty key: $key");
+                throw new InvalidArgumentException('Missing or empty key: ' . $key);
             }
         }
 
         return new self(
-            reservationitems_id: (int) $data['reservationitems_id'],
-            begin: (string) $data['begin'],
-            end: (string) $data['end'],
+            reservationitems_id: $data['reservationitems_id'],
+            begin: $data['begin'],
+            end: $data['end'],
         );
     }
 

--- a/src/Model/QuestionType/ReservationQuestionAnswer.php
+++ b/src/Model/QuestionType/ReservationQuestionAnswer.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\QuestionType;
+
+use InvalidArgumentException;
+
+final readonly class ReservationQuestionAnswer
+{
+    public function __construct(
+        private int $reservationitems_id,
+        private string $begin,
+        private string $end,
+    ) {}
+
+    /**
+     * @param array{
+     *      reservationitems_id: int,
+     *      begin: string,
+     *      end: string
+     * } $data
+     */
+    public static function fromArray(array $data): self
+    {
+        foreach (['reservationitems_id', 'begin', 'end'] as $key) {
+            if (!isset($data[$key]) || $data[$key] === '') {
+                throw new InvalidArgumentException("Missing or empty key: $key");
+            }
+        }
+
+        return new self(
+            reservationitems_id: (int) $data['reservationitems_id'],
+            begin: (string) $data['begin'],
+            end: (string) $data['end'],
+        );
+    }
+
+    /**
+     * @return array{
+     *      reservationitems_id: int,
+     *      begin: string,
+     *      end: string
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'reservationitems_id' => $this->reservationitems_id,
+            'begin' => $this->begin,
+            'end' => $this->end,
+        ];
+    }
+
+    public function getReservationItemsId(): int
+    {
+        return $this->reservationitems_id;
+    }
+
+    public function getBegin(): string
+    {
+        return $this->begin;
+    }
+
+    public function getEnd(): string
+    {
+        return $this->end;
+    }
+
+    public function isValidRange(): bool
+    {
+        return strtotime($this->begin) < strtotime($this->end);
+    }
+}

--- a/src/Model/QuestionType/ReservationQuestionConfig.php
+++ b/src/Model/QuestionType/ReservationQuestionConfig.php
@@ -41,6 +41,9 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
     // Unique reference to hardcoded name used for serialization
     public const ALLOWED_ITEMTYPES = 'allowed_itemtypes';
 
+    /**
+     * @param array<string> $allowed_itemtypes
+     */
     public function __construct(
         private array $allowed_itemtypes = [],
     ) {}
@@ -71,11 +74,17 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
         ];
     }
 
+    /**
+     * @return array<string>
+     */
     public function getAllowedItemtypes(): array
     {
         return $this->allowed_itemtypes;
     }
 
+    /**
+     * @return array<string>
+     */
     public function getEffectiveAllowedItemtypes(): array
     {
         global $CFG_GLPI;
@@ -84,6 +93,10 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
             return $this->allowed_itemtypes;
         }
 
-        return $CFG_GLPI['reservation_types'] ?? [];
+        $reservation_types = $CFG_GLPI['reservation_types'] ?? [];
+
+        return is_array($reservation_types)
+            ? array_values(array_filter($reservation_types, is_string(...)))
+            : [];
     }
 }

--- a/src/Model/QuestionType/ReservationQuestionConfig.php
+++ b/src/Model/QuestionType/ReservationQuestionConfig.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model\QuestionType;
+
+use Glpi\DBAL\JsonFieldInterface;
+use Override;
+
+final readonly class ReservationQuestionConfig implements JsonFieldInterface
+{
+    // Unique reference to hardcoded name used for serialization
+    public const ALLOWED_ITEMTYPES = 'allowed_itemtypes';
+
+    public function __construct(
+        private array $allowed_itemtypes = [],
+    ) {}
+
+    /**
+     * @param array{
+     *      allowed_itemtypes?: array<string>
+     * } $data
+     */
+    #[Override]
+    public static function jsonDeserialize(array $data): self
+    {
+        return new self(
+            allowed_itemtypes: $data[self::ALLOWED_ITEMTYPES] ?? [],
+        );
+    }
+
+    /**
+     * @return array{
+     *      allowed_itemtypes: array<string>
+     * } $data
+     */
+    #[Override]
+    public function jsonSerialize(): array
+    {
+        return [
+            self::ALLOWED_ITEMTYPES => $this->allowed_itemtypes,
+        ];
+    }
+
+    public function getAllowedItemtypes(): array
+    {
+        return $this->allowed_itemtypes;
+    }
+
+    public function getEffectiveAllowedItemtypes(): array
+    {
+        global $CFG_GLPI;
+
+        if ($this->allowed_itemtypes !== []) {
+            return $this->allowed_itemtypes;
+        }
+
+        return $CFG_GLPI['reservation_types'] ?? [];
+    }
+}

--- a/src/Model/QuestionType/ReservationQuestionConfig.php
+++ b/src/Model/QuestionType/ReservationQuestionConfig.php
@@ -41,18 +41,12 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
     // Unique reference to hardcoded name used for serialization
     public const ALLOWED_ITEMTYPES = 'allowed_itemtypes';
 
-    /**
-     * @param array<string> $allowed_itemtypes
-     */
+    /** @param array<string> $allowed_itemtypes */
     public function __construct(
         private array $allowed_itemtypes = [],
     ) {}
 
-    /**
-     * @param array{
-     *      allowed_itemtypes?: array<string>
-     * } $data
-     */
+    /** @param array{allowed_itemtypes?: array<string>} $data */
     #[Override]
     public static function jsonDeserialize(array $data): self
     {
@@ -61,11 +55,7 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
         );
     }
 
-    /**
-     * @return array{
-     *      allowed_itemtypes: array<string>
-     * } $data
-     */
+    /** @return array{allowed_itemtypes: array<string>} */
     #[Override]
     public function jsonSerialize(): array
     {
@@ -74,17 +64,13 @@ final readonly class ReservationQuestionConfig implements JsonFieldInterface
         ];
     }
 
-    /**
-     * @return array<string>
-     */
+    /** @return array<string> */
     public function getAllowedItemtypes(): array
     {
         return $this->allowed_itemtypes;
     }
 
-    /**
-     * @return array<string>
-     */
+    /** @return array<string> */
     public function getEffectiveAllowedItemtypes(): array
     {
         global $CFG_GLPI;

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -39,6 +39,7 @@ use NotificationEvent;
 use Override;
 use Reservation;
 use ReservationItem;
+use Session;
 use Ticket;
 
 use function getItemForItemtype;
@@ -267,7 +268,36 @@ final class TicketReservationRequest extends CommonDBChild
             return false;
         }
 
-        return $ticket->canUpdateItem();
+        if (!$ticket->canUpdateItem()) {
+            return false;
+        }
+
+        // Approving/refusing creates (or would create) a Reservation for this
+        // request's own requester, not for whoever answers it. Mirror core's
+        // rule in Reservation::handleAddForm(): creating a reservation for
+        // someone else requires CREATE, not just RESERVEANITEM.
+        if (
+            $this->getIntField('users_id') !== (int) Session::getLoginUserID()
+            && !Session::haveRight(Reservation::$rightname, CREATE)
+        ) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /** Removes every pending/accepted request tied to a purged Ticket, along with any Reservation it created. */
+    public static function purgeForTicket(Ticket $ticket): void
+    {
+        $request = new self();
+        foreach ($request->find(['tickets_id' => $ticket->getID()]) as $row) {
+            if (!is_array($row) || !isset($row['id']) || !is_numeric($row['id'])) {
+                continue;
+            }
+
+            $item = new self();
+            $item->delete(['id' => (int) $row['id']], true);
+        }
     }
 
     private function getIntField(string $field): int

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -34,6 +34,7 @@
 namespace GlpiPlugin\Advancedforms\Model;
 
 use CommonDBChild;
+use NotificationEvent;
 use Override;
 use Reservation;
 use Ticket;
@@ -75,6 +76,21 @@ final class TicketReservationRequest extends CommonDBChild
     public static function getIcon(): string
     {
         return 'ti ti-calendar-event';
+    }
+
+    #[Override]
+    public function post_addItem(): void
+    {
+        parent::post_addItem();
+
+        // Only notify ticket actors that a new request needs an answer when
+        // the request is actually created in a waiting state. A request
+        // created already accepted (e.g. a future "direct reservation, no
+        // approval needed" path) has nothing to approve/refuse, so it must
+        // not raise this event.
+        if ((int) $this->fields['status'] === self::STATUS_WAITING) {
+            NotificationEvent::raiseEvent('reservation_request_created', $this);
+        }
     }
 
     /**
@@ -128,13 +144,19 @@ final class TicketReservationRequest extends CommonDBChild
             return false;
         }
 
-        return $this->update([
+        $updated = $this->update([
             'id' => $this->getID(),
             'status' => self::STATUS_ACCEPTED,
             'users_id_validate' => $users_id_validate,
             'comment_validation' => $comment,
             'validation_date' => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
         ]);
+
+        if ($updated) {
+            NotificationEvent::raiseEvent('reservation_request_approved', $this);
+        }
+
+        return $updated;
     }
 
     /**
@@ -145,25 +167,37 @@ final class TicketReservationRequest extends CommonDBChild
      */
     public function refuse(int $users_id_validate, string $comment = ''): bool
     {
-        return $this->update([
+        $updated = $this->update([
             'id' => $this->getID(),
             'status' => self::STATUS_REFUSED,
             'users_id_validate' => $users_id_validate,
             'comment_validation' => $comment,
             'validation_date' => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
         ]);
+
+        if ($updated) {
+            NotificationEvent::raiseEvent('reservation_request_refused', $this);
+        }
+
+        return $updated;
     }
 
     /**
      * Mark this request as no longer available (e.g. the reservable item was
-     * removed or deactivated). No notification is raised here.
+     * removed or deactivated).
      */
     public function markUnavailable(): bool
     {
-        return $this->update([
+        $updated = $this->update([
             'id' => $this->getID(),
             'status' => self::STATUS_CANCELED,
         ]);
+
+        if ($updated) {
+            NotificationEvent::raiseEvent('reservation_request_slot_unavailable', $this);
+        }
+
+        return $updated;
     }
 
     /**

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -88,7 +88,21 @@ final class TicketReservationRequest extends CommonDBChild
         // created already accepted (e.g. a future "direct reservation, no
         // approval needed" path) has nothing to approve/refuse, so it must
         // not raise this event.
-        if ((int) $this->fields['status'] === self::STATUS_WAITING) {
+        //
+        // A caller can also explicitly opt out of this notification (via the
+        // standard `_disablenotif` input key, see `CommonDBTM`/`Ticket`/etc.)
+        // even while inserting the row in the WAITING state: this is used by
+        // `PreReservationField` for its "no approval required" (direct
+        // reservation) path, where the row is inserted as WAITING only as a
+        // transient step before immediately transitioning it to its real
+        // final state (ACCEPTED/CANCELED) via `approve()`/`markUnavailable()`,
+        // which each raise their own distinct event. Without this, the
+        // "please wait for approval" notification would fire for something
+        // that never actually waits for approval.
+        if (
+            (int) $this->fields['status'] === self::STATUS_WAITING
+            && !isset($this->input['_disablenotif'])
+        ) {
             NotificationEvent::raiseEvent('reservation_request_created', $this);
         }
     }

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -48,12 +48,17 @@ use Ticket;
 final class TicketReservationRequest extends CommonDBChild
 {
     public static $itemtype = 'Ticket';
+
     public static $items_id = 'tickets_id';
+
     public static $rightname = 'ticket';
 
     public const STATUS_WAITING  = 1;
+
     public const STATUS_ACCEPTED = 2;
+
     public const STATUS_REFUSED  = 3;
+
     public const STATUS_CANCELED = 4;
 
     #[Override]

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -34,10 +34,14 @@
 namespace GlpiPlugin\Advancedforms\Model;
 
 use CommonDBChild;
+use CommonDBTM;
 use NotificationEvent;
 use Override;
 use Reservation;
+use ReservationItem;
 use Ticket;
+
+use function getItemForItemtype;
 
 /** A ticket-driven request to reserve an equipment item for a timeframe. */
 final class TicketReservationRequest extends CommonDBChild
@@ -87,8 +91,12 @@ final class TicketReservationRequest extends CommonDBChild
         }
     }
 
-    /** Mirrors core's Reservation::is_reserved() overlap check (strict inequalities). */
-    public function isSlotStillAvailable(): bool
+    /**
+     * Whether no existing Reservation overlaps the given slot for the item.
+     * Single source of truth for the overlap check, mirroring core's
+     * Reservation::is_reserved() (strict inequalities, back-to-back slots allowed).
+     */
+    public static function isSlotFree(int $reservationitems_id, string $begin, string $end): bool
     {
         global $DB;
 
@@ -96,9 +104,9 @@ final class TicketReservationRequest extends CommonDBChild
             'COUNT' => 'cpt',
             'FROM' => Reservation::getTable(),
             'WHERE' => [
-                'reservationitems_id' => $this->fields['reservationitems_id'],
-                'end' => ['>', $this->fields['begin']],
-                'begin' => ['<', $this->fields['end']],
+                'reservationitems_id' => $reservationitems_id,
+                'end' => ['>', $begin],
+                'begin' => ['<', $end],
             ],
         ])->current();
 
@@ -107,6 +115,15 @@ final class TicketReservationRequest extends CommonDBChild
             : 0;
 
         return $count === 0;
+    }
+
+    public function isSlotStillAvailable(): bool
+    {
+        return self::isSlotFree(
+            $this->getIntField('reservationitems_id'),
+            $this->getNullableStringField('begin') ?? '',
+            $this->getNullableStringField('end') ?? '',
+        );
     }
 
     /** Creates the Reservation for the original requester and accepts this request; returns false, untouched, if the slot is no longer available. */
@@ -130,6 +147,8 @@ final class TicketReservationRequest extends CommonDBChild
             'status' => self::STATUS_ACCEPTED,
             'users_id_validate' => $users_id_validate,
             'comment_validation' => $comment,
+            // Keep a link back to the created Reservation for traceability and cleanup.
+            'reservations_id' => $reservation->getID(),
             'validation_date' => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
         ]);
 
@@ -157,7 +176,22 @@ final class TicketReservationRequest extends CommonDBChild
         return $updated;
     }
 
-    /** Marks this request canceled (e.g. the reservable item was removed or deactivated). */
+    /** Removes the Reservation created on approval so it never outlives its request. */
+    #[Override]
+    public function pre_deleteItem(): bool
+    {
+        $reservations_id = $this->getIntField('reservations_id');
+        if ($reservations_id > 0) {
+            $reservation = new Reservation();
+            if ($reservation->getFromDB($reservations_id)) {
+                $reservation->delete(['id' => $reservations_id]);
+            }
+        }
+
+        return parent::pre_deleteItem();
+    }
+
+    /** Marks this request canceled (slot no longer available, e.g. taken during a direct reservation). */
     public function markUnavailable(): bool
     {
         $updated = $this->update([
@@ -197,6 +231,28 @@ final class TicketReservationRequest extends CommonDBChild
             'is_direct_reservation' => $this->getIntField('status') === self::STATUS_ACCEPTED
                 && $this->getIntField('users_id_validate') === 0,
         ];
+    }
+
+    /** Resolves the reservable asset's display name; empty string if it no longer exists. */
+    public static function getReservableItemName(int $reservationitems_id): string
+    {
+        $reservation_item = new ReservationItem();
+        if (!$reservation_item->getFromDB($reservationitems_id)) {
+            return '';
+        }
+
+        $itemtype = $reservation_item->fields['itemtype'] ?? '';
+        $itemtype = is_string($itemtype) ? $itemtype : '';
+
+        $items_id = $reservation_item->fields['items_id'] ?? 0;
+        $items_id = is_numeric($items_id) ? (int) $items_id : 0;
+
+        $item = getItemForItemtype($itemtype);
+        if (!$item instanceof CommonDBTM || !$item->getFromDB($items_id)) {
+            return '';
+        }
+
+        return $item->getName();
     }
 
     /** Whether the current user may approve/refuse this still-waiting request. */

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Model;
+
+use CommonDBChild;
+use Override;
+use Reservation;
+use Ticket;
+
+/**
+ * A request, made from a ticket, to reserve a reservable item (asset) for a
+ * given timeframe. It is created by the "reservation" question type's
+ * destination field and must be approved or refused by a ticket actor before
+ * an actual `Reservation` is created.
+ */
+final class TicketReservationRequest extends CommonDBChild
+{
+    public static $itemtype = 'Ticket';
+    public static $items_id = 'tickets_id';
+    public static $rightname = 'ticket';
+
+    public const STATUS_WAITING  = 1;
+    public const STATUS_ACCEPTED = 2;
+    public const STATUS_REFUSED  = 3;
+    public const STATUS_CANCELED = 4;
+
+    #[Override]
+    public static function getTable($classname = null): string
+    {
+        // The default table name computation (based on the fully qualified
+        // class name) would produce `glpi_plugin_advancedforms_models_ticketreservationrequests`
+        // because of the `Model` sub-namespace. The table must be forced to
+        // its expected name instead.
+        return 'glpi_plugin_advancedforms_ticketreservationrequests';
+    }
+
+    #[Override]
+    public static function getTypeName($nb = 0): string
+    {
+        return _n('Reservation request', 'Reservation requests', $nb, 'advancedforms');
+    }
+
+    #[Override]
+    public static function getIcon(): string
+    {
+        return 'ti ti-calendar-event';
+    }
+
+    /**
+     * Whether the requested reservation item is still free for this
+     * request's timeframe, i.e. no existing `Reservation` overlaps it.
+     *
+     * Mirrors core's `Reservation::is_reserved()` conflict detection exactly
+     * (strict inequalities: `end > begin AND begin < end`).
+     */
+    public function isSlotStillAvailable(): bool
+    {
+        global $DB;
+
+        $conflicts = $DB->request([
+            'COUNT' => 'cpt',
+            'FROM' => Reservation::getTable(),
+            'WHERE' => [
+                'reservationitems_id' => $this->fields['reservationitems_id'],
+                'end' => ['>', $this->fields['begin']],
+                'begin' => ['<', $this->fields['end']],
+            ],
+        ])->current();
+
+        return ((int) $conflicts['cpt']) === 0;
+    }
+
+    /**
+     * Approve this request: create the actual `Reservation` (attributed to
+     * the original requester, not the validator) and mark this request as
+     * accepted.
+     *
+     * @param int    $users_id_validate Id of the user validating the request
+     * @param string $comment           Optional comment from the validator
+     *
+     * @return bool False if the `Reservation` could not be created (for
+     *              instance because the slot is no longer available); in
+     *              that case, this request is left untouched.
+     */
+    public function approve(int $users_id_validate, string $comment = ''): bool
+    {
+        $reservation = new Reservation();
+        $created = $reservation->add([
+            'reservationitems_id' => $this->fields['reservationitems_id'],
+            'begin' => $this->fields['begin'],
+            'end' => $this->fields['end'],
+            'users_id' => $this->fields['users_id'], // original requester, not the validator
+            'comment' => $this->fields['comment_submission'] ?? '',
+        ]);
+
+        if (!$created) {
+            return false;
+        }
+
+        return $this->update([
+            'id' => $this->getID(),
+            'status' => self::STATUS_ACCEPTED,
+            'users_id_validate' => $users_id_validate,
+            'comment_validation' => $comment,
+            'validation_date' => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    /**
+     * Refuse this request. No `Reservation` is created.
+     *
+     * @param int    $users_id_validate Id of the user refusing the request
+     * @param string $comment           Optional comment from the validator
+     */
+    public function refuse(int $users_id_validate, string $comment = ''): bool
+    {
+        return $this->update([
+            'id' => $this->getID(),
+            'status' => self::STATUS_REFUSED,
+            'users_id_validate' => $users_id_validate,
+            'comment_validation' => $comment,
+            'validation_date' => $_SESSION['glpi_currenttime'] ?? date('Y-m-d H:i:s'),
+        ]);
+    }
+
+    /**
+     * Mark this request as no longer available (e.g. the reservable item was
+     * removed or deactivated). No notification is raised here.
+     */
+    public function markUnavailable(): bool
+    {
+        return $this->update([
+            'id' => $this->getID(),
+            'status' => self::STATUS_CANCELED,
+        ]);
+    }
+
+    /**
+     * Data needed to render this request in a ticket's timeline.
+     *
+     * @return array{
+     *     id: int,
+     *     status: int,
+     *     reservationitems_id: int,
+     *     begin: string|null,
+     *     end: string|null,
+     *     comment_validation: string,
+     *     can_answer: bool,
+     *     is_direct_reservation: bool,
+     * }
+     */
+    public function getTimelineInfo(): array
+    {
+        return [
+            'id' => $this->getID(),
+            'status' => (int) $this->fields['status'],
+            'reservationitems_id' => (int) $this->fields['reservationitems_id'],
+            'begin' => $this->fields['begin'],
+            'end' => $this->fields['end'],
+            'comment_validation' => $this->fields['comment_validation'] ?? '',
+            'can_answer' => $this->canAnswer(),
+            'is_direct_reservation' => (int) $this->fields['status'] === self::STATUS_ACCEPTED
+                && (int) $this->fields['users_id_validate'] === 0,
+        ];
+    }
+
+    /**
+     * Whether the current session's user may approve/refuse this request:
+     * it must still be waiting, and the user must be able to update the
+     * parent ticket.
+     */
+    public function canAnswer(): bool
+    {
+        if ((int) $this->fields['status'] !== self::STATUS_WAITING) {
+            return false;
+        }
+
+        $ticket = new Ticket();
+        if (!$ticket->getFromDB($this->fields['tickets_id'])) {
+            return false;
+        }
+
+        return $ticket->canUpdateItem();
+    }
+}

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -105,7 +105,7 @@ final class TicketReservationRequest extends CommonDBChild
         // "please wait for approval" notification would fire for something
         // that never actually waits for approval.
         if (
-            (int) $this->fields['status'] === self::STATUS_WAITING
+            $this->getIntField('status') === self::STATUS_WAITING
             && !isset($this->input['_disablenotif'])
         ) {
             NotificationEvent::raiseEvent('reservation_request_created', $this);
@@ -133,7 +133,11 @@ final class TicketReservationRequest extends CommonDBChild
             ],
         ])->current();
 
-        return ((int) $conflicts['cpt']) === 0;
+        $count = is_array($conflicts) && is_numeric($conflicts['cpt'] ?? null)
+            ? (int) $conflicts['cpt']
+            : 0;
+
+        return $count === 0;
     }
 
     /**
@@ -237,14 +241,14 @@ final class TicketReservationRequest extends CommonDBChild
     {
         return [
             'id' => $this->getID(),
-            'status' => (int) $this->fields['status'],
-            'reservationitems_id' => (int) $this->fields['reservationitems_id'],
-            'begin' => $this->fields['begin'],
-            'end' => $this->fields['end'],
-            'comment_validation' => $this->fields['comment_validation'] ?? '',
+            'status' => $this->getIntField('status'),
+            'reservationitems_id' => $this->getIntField('reservationitems_id'),
+            'begin' => $this->getNullableStringField('begin'),
+            'end' => $this->getNullableStringField('end'),
+            'comment_validation' => $this->getNullableStringField('comment_validation') ?? '',
             'can_answer' => $this->canAnswer(),
-            'is_direct_reservation' => (int) $this->fields['status'] === self::STATUS_ACCEPTED
-                && (int) $this->fields['users_id_validate'] === 0,
+            'is_direct_reservation' => $this->getIntField('status') === self::STATUS_ACCEPTED
+                && $this->getIntField('users_id_validate') === 0,
         ];
     }
 
@@ -255,15 +259,29 @@ final class TicketReservationRequest extends CommonDBChild
      */
     public function canAnswer(): bool
     {
-        if ((int) $this->fields['status'] !== self::STATUS_WAITING) {
+        if ($this->getIntField('status') !== self::STATUS_WAITING) {
             return false;
         }
 
         $ticket = new Ticket();
-        if (!$ticket->getFromDB($this->fields['tickets_id'])) {
+        if (!$ticket->getFromDB($this->getIntField('tickets_id'))) {
             return false;
         }
 
         return $ticket->canUpdateItem();
+    }
+
+    private function getIntField(string $field): int
+    {
+        $value = $this->fields[$field] ?? null;
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+
+    private function getNullableStringField(string $field): ?string
+    {
+        $value = $this->fields[$field] ?? null;
+
+        return is_string($value) ? $value : null;
     }
 }

--- a/src/Model/TicketReservationRequest.php
+++ b/src/Model/TicketReservationRequest.php
@@ -39,12 +39,7 @@ use Override;
 use Reservation;
 use Ticket;
 
-/**
- * A request, made from a ticket, to reserve a reservable item (asset) for a
- * given timeframe. It is created by the "reservation" question type's
- * destination field and must be approved or refused by a ticket actor before
- * an actual `Reservation` is created.
- */
+/** A ticket-driven request to reserve an equipment item for a timeframe. */
 final class TicketReservationRequest extends CommonDBChild
 {
     public static $itemtype = 'Ticket';
@@ -64,10 +59,6 @@ final class TicketReservationRequest extends CommonDBChild
     #[Override]
     public static function getTable($classname = null): string
     {
-        // The default table name computation (based on the fully qualified
-        // class name) would produce `glpi_plugin_advancedforms_models_ticketreservationrequests`
-        // because of the `Model` sub-namespace. The table must be forced to
-        // its expected name instead.
         return 'glpi_plugin_advancedforms_ticketreservationrequests';
     }
 
@@ -88,22 +79,6 @@ final class TicketReservationRequest extends CommonDBChild
     {
         parent::post_addItem();
 
-        // Only notify ticket actors that a new request needs an answer when
-        // the request is actually created in a waiting state. A request
-        // created already accepted (e.g. a future "direct reservation, no
-        // approval needed" path) has nothing to approve/refuse, so it must
-        // not raise this event.
-        //
-        // A caller can also explicitly opt out of this notification (via the
-        // standard `_disablenotif` input key, see `CommonDBTM`/`Ticket`/etc.)
-        // even while inserting the row in the WAITING state: this is used by
-        // `PreReservationField` for its "no approval required" (direct
-        // reservation) path, where the row is inserted as WAITING only as a
-        // transient step before immediately transitioning it to its real
-        // final state (ACCEPTED/CANCELED) via `approve()`/`markUnavailable()`,
-        // which each raise their own distinct event. Without this, the
-        // "please wait for approval" notification would fire for something
-        // that never actually waits for approval.
         if (
             $this->getIntField('status') === self::STATUS_WAITING
             && !isset($this->input['_disablenotif'])
@@ -112,13 +87,7 @@ final class TicketReservationRequest extends CommonDBChild
         }
     }
 
-    /**
-     * Whether the requested reservation item is still free for this
-     * request's timeframe, i.e. no existing `Reservation` overlaps it.
-     *
-     * Mirrors core's `Reservation::is_reserved()` conflict detection exactly
-     * (strict inequalities: `end > begin AND begin < end`).
-     */
+    /** Mirrors core's Reservation::is_reserved() overlap check (strict inequalities). */
     public function isSlotStillAvailable(): bool
     {
         global $DB;
@@ -140,18 +109,7 @@ final class TicketReservationRequest extends CommonDBChild
         return $count === 0;
     }
 
-    /**
-     * Approve this request: create the actual `Reservation` (attributed to
-     * the original requester, not the validator) and mark this request as
-     * accepted.
-     *
-     * @param int    $users_id_validate Id of the user validating the request
-     * @param string $comment           Optional comment from the validator
-     *
-     * @return bool False if the `Reservation` could not be created (for
-     *              instance because the slot is no longer available); in
-     *              that case, this request is left untouched.
-     */
+    /** Creates the Reservation for the original requester and accepts this request; returns false, untouched, if the slot is no longer available. */
     public function approve(int $users_id_validate, string $comment = ''): bool
     {
         $reservation = new Reservation();
@@ -159,7 +117,7 @@ final class TicketReservationRequest extends CommonDBChild
             'reservationitems_id' => $this->fields['reservationitems_id'],
             'begin' => $this->fields['begin'],
             'end' => $this->fields['end'],
-            'users_id' => $this->fields['users_id'], // original requester, not the validator
+            'users_id' => $this->fields['users_id'],
             'comment' => $this->fields['comment_submission'] ?? '',
         ]);
 
@@ -182,12 +140,6 @@ final class TicketReservationRequest extends CommonDBChild
         return $updated;
     }
 
-    /**
-     * Refuse this request. No `Reservation` is created.
-     *
-     * @param int    $users_id_validate Id of the user refusing the request
-     * @param string $comment           Optional comment from the validator
-     */
     public function refuse(int $users_id_validate, string $comment = ''): bool
     {
         $updated = $this->update([
@@ -205,10 +157,7 @@ final class TicketReservationRequest extends CommonDBChild
         return $updated;
     }
 
-    /**
-     * Mark this request as no longer available (e.g. the reservable item was
-     * removed or deactivated).
-     */
+    /** Marks this request canceled (e.g. the reservable item was removed or deactivated). */
     public function markUnavailable(): bool
     {
         $updated = $this->update([
@@ -224,8 +173,6 @@ final class TicketReservationRequest extends CommonDBChild
     }
 
     /**
-     * Data needed to render this request in a ticket's timeline.
-     *
      * @return array{
      *     id: int,
      *     status: int,
@@ -252,11 +199,7 @@ final class TicketReservationRequest extends CommonDBChild
         ];
     }
 
-    /**
-     * Whether the current session's user may approve/refuse this request:
-     * it must still be waiting, and the user must be able to update the
-     * parent ticket.
-     */
+    /** Whether the current user may approve/refuse this still-waiting request. */
     public function canAnswer(): bool
     {
         if ($this->getIntField('status') !== self::STATUS_WAITING) {

--- a/src/Service/ConfigManager.php
+++ b/src/Service/ConfigManager.php
@@ -42,8 +42,8 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\HiddenQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\HostnameQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\IpAddressQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
-use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
 
 final class ConfigManager

--- a/src/Service/ConfigManager.php
+++ b/src/Service/ConfigManager.php
@@ -43,6 +43,7 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\HostnameQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\IpAddressQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LdapQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
 
 final class ConfigManager
@@ -68,6 +69,7 @@ final class ConfigManager
             new LdapQuestion(),
             new TreeCascadeDropdownQuestion(),
             new TableQuestion(),
+            new ReservationQuestion(),
         ];
     }
 

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -106,13 +106,7 @@ final class InitManager
     {
         $destination_manager = FormDestinationManager::getInstance();
 
-        // `FormDestinationManager` is a plain singleton with no way to
-        // unregister a field: `init()` may legitimately be called several
-        // times during the same request/process (e.g. once automatically on
-        // plugin boot, then again whenever a configurable item is toggled).
-        // Guard against registering the same field more than once, which
-        // would otherwise make `applyConfiguratedValueAfterDestinationCreation()`
-        // run multiple times per created ticket.
+        // init() may run multiple times per process; avoid double-registering the field.
         $already_registered = array_filter(
             $destination_manager->getPluginCommonITILConfigFields(FormDestinationTicket::class),
             fn($field) => $field instanceof PreReservationField,

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -34,11 +34,14 @@
 namespace GlpiPlugin\Advancedforms\Service;
 
 use Config;
+use Glpi\Form\Destination\FormDestinationManager;
+use Glpi\Form\Destination\FormDestinationTicket;
 use Glpi\Form\Migration\TypesConversionMapper;
 use Glpi\Form\QuestionType\QuestionTypesManager;
 use Glpi\Plugin\Hooks;
 use Glpi\Toolbox\SingletonTrait;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigTab;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
 use GlpiPlugin\Advancedforms\Model\QuestionType\AdvancedCategory;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LegacyQuestionTypeInterface;
 use Plugin;
@@ -51,6 +54,7 @@ final class InitManager
     {
         $this->registerConfiguration();
         $this->registerPluginTypes();
+        $this->registerDestinationFields();
     }
 
     private function registerConfiguration(): void
@@ -95,5 +99,30 @@ final class InitManager
                 );
             }
         }
+    }
+
+    private function registerDestinationFields(): void
+    {
+        $destination_manager = FormDestinationManager::getInstance();
+
+        // `FormDestinationManager` is a plain singleton with no way to
+        // unregister a field: `init()` may legitimately be called several
+        // times during the same request/process (e.g. once automatically on
+        // plugin boot, then again whenever a configurable item is toggled).
+        // Guard against registering the same field more than once, which
+        // would otherwise make `applyConfiguratedValueAfterDestinationCreation()`
+        // run multiple times per created ticket.
+        $already_registered = array_filter(
+            $destination_manager->getPluginCommonITILConfigFields(FormDestinationTicket::class),
+            fn($field) => $field instanceof PreReservationField,
+        );
+        if ($already_registered !== []) {
+            return;
+        }
+
+        $destination_manager->registerPluginCommonITILConfigField(
+            FormDestinationTicket::class,
+            new PreReservationField(),
+        );
     }
 }

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -46,6 +46,7 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\AdvancedCategory;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LegacyQuestionTypeInterface;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use Plugin;
+use Ticket;
 
 final class InitManager
 {
@@ -58,6 +59,7 @@ final class InitManager
         $this->registerDestinationFields();
         $this->registerTimelineHooks();
         $this->registerNotifications();
+        $this->registerPurgeHooks();
     }
 
     private function registerNotifications(): void
@@ -144,5 +146,16 @@ final class InitManager
 
         // @phpstan-ignore offsetAccess.nonOffsetAccessible (we don't have type hint for this array at this time)
         $PLUGIN_HOOKS[Hooks::TIMELINE_ITEMS]['advancedforms'] = TimelineManager::addTimelineItems(...);
+    }
+
+    /** Cleans up reservation requests (and the Reservation they created) when their Ticket is purged. */
+    private function registerPurgeHooks(): void
+    {
+        global $PLUGIN_HOOKS;
+
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible (we don't have type hint for this array at this time)
+        $PLUGIN_HOOKS[Hooks::ITEM_PURGE]['advancedforms'] = [
+            Ticket::class => TicketReservationRequest::purgeForTicket(...),
+        ];
     }
 }

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -132,6 +132,6 @@ final class InitManager
         global $PLUGIN_HOOKS;
 
         // @phpstan-ignore offsetAccess.nonOffsetAccessible (we don't have type hint for this array at this time)
-        $PLUGIN_HOOKS[Hooks::TIMELINE_ITEMS]['advancedforms'] = [TimelineManager::class, 'addTimelineItems'];
+        $PLUGIN_HOOKS[Hooks::TIMELINE_ITEMS]['advancedforms'] = TimelineManager::addTimelineItems(...);
     }
 }

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -44,6 +44,7 @@ use GlpiPlugin\Advancedforms\Model\Config\ConfigTab;
 use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
 use GlpiPlugin\Advancedforms\Model\QuestionType\AdvancedCategory;
 use GlpiPlugin\Advancedforms\Model\QuestionType\LegacyQuestionTypeInterface;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use Plugin;
 
 final class InitManager
@@ -56,6 +57,22 @@ final class InitManager
         $this->registerPluginTypes();
         $this->registerDestinationFields();
         $this->registerTimelineHooks();
+        $this->registerNotifications();
+    }
+
+    private function registerNotifications(): void
+    {
+        global $CFG_GLPI;
+
+        $itemtype = TicketReservationRequest::class;
+
+        // init() may run multiple times per process; avoid duplicate registration.
+        $registered = $CFG_GLPI['notificationtemplates_types'] ?? [];
+        if (is_array($registered) && in_array($itemtype, $registered, true)) {
+            return;
+        }
+
+        Plugin::registerClass($itemtype, ['notificationtemplates_types' => true]);
     }
 
     private function registerConfiguration(): void

--- a/src/Service/InitManager.php
+++ b/src/Service/InitManager.php
@@ -55,6 +55,7 @@ final class InitManager
         $this->registerConfiguration();
         $this->registerPluginTypes();
         $this->registerDestinationFields();
+        $this->registerTimelineHooks();
     }
 
     private function registerConfiguration(): void
@@ -124,5 +125,13 @@ final class InitManager
             FormDestinationTicket::class,
             new PreReservationField(),
         );
+    }
+
+    private function registerTimelineHooks(): void
+    {
+        global $PLUGIN_HOOKS;
+
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible (we don't have type hint for this array at this time)
+        $PLUGIN_HOOKS[Hooks::TIMELINE_ITEMS]['advancedforms'] = [TimelineManager::class, 'addTimelineItems'];
     }
 }

--- a/src/Service/InstallManager.php
+++ b/src/Service/InstallManager.php
@@ -36,13 +36,48 @@ namespace GlpiPlugin\Advancedforms\Service;
 use DBmysql;
 use Config;
 use DBConnection;
+use Glpi\DBAL\QueryExpression;
 use Glpi\Toolbox\SingletonTrait;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use Migration;
+use Notification;
+use Notification_NotificationTemplate;
+use NotificationTemplate;
+use NotificationTemplateTranslation;
+
+use function countElementsInTable;
 
 final class InstallManager
 {
     use SingletonTrait;
+
+    /**
+     * Notifications seeded at install, keyed by event.
+     * Each target is [items_id, type] as stored in glpi_notificationtargets.
+     *
+     * Only the requester (AUTHOR) is targeted out of the box: it is the reliable
+     * recipient for a request-scoped itemtype. Notifying the ticket's assigned
+     * technicians would require a custom target resolving the linked ticket, so
+     * it is left for admins to add (or a follow-up), not seeded here.
+     */
+    private const NOTIFICATIONS = [
+        'reservation_request_created' => [
+            'name' => 'New pre-reservation request',
+            'targets' => [[Notification::AUTHOR, Notification::USER_TYPE]],
+        ],
+        'reservation_request_approved' => [
+            'name' => 'Pre-reservation request approved',
+            'targets' => [[Notification::AUTHOR, Notification::USER_TYPE]],
+        ],
+        'reservation_request_refused' => [
+            'name' => 'Pre-reservation request refused',
+            'targets' => [[Notification::AUTHOR, Notification::USER_TYPE]],
+        ],
+        'reservation_request_slot_unavailable' => [
+            'name' => 'Reservation slot no longer available',
+            'targets' => [[Notification::AUTHOR, Notification::USER_TYPE]],
+        ],
+    ];
 
     public function install(): bool
     {
@@ -51,6 +86,7 @@ final class InstallManager
         $migration = new Migration(PLUGIN_ADVANCEDFORMS_VERSION);
 
         $this->installTicketReservationRequestsTable($DB);
+        $this->installNotifications();
 
         $migration->executeMigration();
 
@@ -73,6 +109,7 @@ final class InstallManager
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `tickets_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `reservationitems_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `reservations_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `begin` timestamp NULL DEFAULT NULL,
             `end` timestamp NULL DEFAULT NULL,
@@ -86,12 +123,115 @@ final class InstallManager
             PRIMARY KEY (`id`),
             KEY `tickets_id` (`tickets_id`),
             KEY `reservationitems_id` (`reservationitems_id`),
+            KEY `reservations_id` (`reservations_id`),
             KEY `users_id` (`users_id`),
             KEY `status` (`status`),
             KEY `date_creation` (`date_creation`)
         ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
 
         $DB->doQuery($query);
+    }
+
+    /**
+     * Seeds a mail template + one active notification per reservation event so
+     * the feature works out of the box. Idempotent: existing rows are left as-is
+     * (admins may have customized them).
+     */
+    private function installNotifications(): void
+    {
+        global $DB;
+
+        $itemtype = TicketReservationRequest::class;
+
+        $templates_id = $this->ensureNotificationTemplate($itemtype);
+        if ($templates_id <= 0) {
+            return;
+        }
+
+        foreach (self::NOTIFICATIONS as $event => $definition) {
+            if (countElementsInTable(Notification::getTable(), ['itemtype' => $itemtype, 'event' => $event]) > 0) {
+                continue;
+            }
+
+            // Raw inserts (like core install/migration seeding): no login context required.
+            $DB->insert(Notification::getTable(), [
+                'name'          => $definition['name'],
+                'entities_id'   => 0,
+                'is_recursive'  => 1,
+                'is_active'     => 1,
+                'itemtype'      => $itemtype,
+                'event'         => $event,
+                'comment'       => '',
+                'date_creation' => new QueryExpression('NOW()'),
+                'date_mod'      => new QueryExpression('NOW()'),
+            ]);
+            $insert_id = $DB->insertId();
+            $notifications_id = is_numeric($insert_id) ? (int) $insert_id : 0;
+            if ($notifications_id <= 0) {
+                continue;
+            }
+
+            $DB->insert(Notification_NotificationTemplate::getTable(), [
+                'notifications_id'         => $notifications_id,
+                'mode'                     => Notification_NotificationTemplate::MODE_MAIL,
+                'notificationtemplates_id' => $templates_id,
+            ]);
+
+            foreach ($definition['targets'] as [$items_id, $type]) {
+                $DB->insert('glpi_notificationtargets', [
+                    'notifications_id' => $notifications_id,
+                    'items_id'         => $items_id,
+                    'type'             => $type,
+                ]);
+            }
+        }
+    }
+
+    /** Returns the id of the (created if needed) shared mail template for reservation requests. */
+    private function ensureNotificationTemplate(string $itemtype): int
+    {
+        global $DB;
+
+        $template = new NotificationTemplate();
+        if ($template->getFromDBByCrit(['itemtype' => $itemtype])) {
+            return (int) $template->getID();
+        }
+
+        $DB->insert(NotificationTemplate::getTable(), [
+            'name'          => 'Reservation requests',
+            'itemtype'      => $itemtype,
+            'comment'       => '',
+            'css'           => '',
+            'date_creation' => new QueryExpression('NOW()'),
+            'date_mod'      => new QueryExpression('NOW()'),
+        ]);
+        $insert_id = $DB->insertId();
+        $templates_id = is_numeric($insert_id) ? (int) $insert_id : 0;
+        if ($templates_id <= 0) {
+            return 0;
+        }
+
+        $content_html = <<<'HTML'
+            <p>##reservationrequest.action##</p>
+            <p>##reservationrequest.begin## &rarr; ##reservationrequest.end##</p>
+            <p>##reservationrequest.comment##</p>
+            <p><a href="##reservationrequest.ticket_url##">##reservationrequest.ticket_url##</a></p>
+            HTML;
+
+        $content_text = "##reservationrequest.action##\n"
+            . "##reservationrequest.begin## -> ##reservationrequest.end##\n"
+            . "##reservationrequest.comment##\n"
+            . "##reservationrequest.ticket_url##";
+
+        $DB->insert(NotificationTemplateTranslation::getTable(), [
+            'notificationtemplates_id' => $templates_id,
+            'language'                 => '',
+            'subject'                  => '##reservationrequest.action## - ##reservationrequest.ticket_title##',
+            'content_html'             => $content_html,
+            'content_text'             => $content_text,
+        ]);
+
+        return $templates_id;
     }
 
     public function uninstall(): bool
@@ -101,11 +241,44 @@ final class InstallManager
         $config = new Config();
         $config->deleteByCriteria(['context' => 'advancedforms']);
 
+        $this->uninstallNotifications();
+
         $table = TicketReservationRequest::getTable();
         if ($DB->tableExists($table, false)) {
             $DB->dropTable($table);
         }
 
         return true;
+    }
+
+    /** Removes every notification artifact seeded by installNotifications(). */
+    private function uninstallNotifications(): void
+    {
+        global $DB;
+
+        $itemtype = TicketReservationRequest::class;
+
+        foreach ($DB->request(['SELECT' => 'id', 'FROM' => Notification::getTable(), 'WHERE' => ['itemtype' => $itemtype]]) as $row) {
+            if (!is_array($row) || !is_numeric($row['id'] ?? null)) {
+                continue;
+            }
+
+            $notifications_id = (int) $row['id'];
+            $DB->delete('glpi_notificationtargets', ['notifications_id' => $notifications_id]);
+            $DB->delete(Notification_NotificationTemplate::getTable(), ['notifications_id' => $notifications_id]);
+        }
+
+        $DB->delete(Notification::getTable(), ['itemtype' => $itemtype]);
+
+        foreach ($DB->request(['SELECT' => 'id', 'FROM' => NotificationTemplate::getTable(), 'WHERE' => ['itemtype' => $itemtype]]) as $row) {
+            if (!is_array($row) || !is_numeric($row['id'] ?? null)) {
+                continue;
+            }
+
+            $templates_id = (int) $row['id'];
+            $DB->delete(NotificationTemplateTranslation::getTable(), ['notificationtemplates_id' => $templates_id]);
+        }
+
+        $DB->delete(NotificationTemplate::getTable(), ['itemtype' => $itemtype]);
     }
 }

--- a/src/Service/InstallManager.php
+++ b/src/Service/InstallManager.php
@@ -34,7 +34,10 @@
 namespace GlpiPlugin\Advancedforms\Service;
 
 use Config;
+use DBConnection;
 use Glpi\Toolbox\SingletonTrait;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Migration;
 
 final class InstallManager
 {
@@ -42,7 +45,57 @@ final class InstallManager
 
     public function install(): bool
     {
+        global $DB;
+
+        $migration = new Migration(PLUGIN_ADVANCEDFORMS_VERSION);
+
+        $this->installTicketReservationRequestsTable($DB);
+
+        // No addField()/addKey()/... calls are queued on `$migration` yet
+        // (the table above is created with a plain, guarded `CREATE TABLE`),
+        // so this call is currently a no-op. It is kept as a safety net so
+        // that any future schema change added here (e.g. via `addField()`)
+        // is not silently forgotten, matching the convention used by other
+        // GLPI plugins (see `plugins/fields/hook.php`).
+        $migration->executeMigration();
+
         return true;
+    }
+
+    private function installTicketReservationRequestsTable(\DBmysql $DB): void
+    {
+        $table = TicketReservationRequest::getTable();
+        if ($DB->tableExists($table)) {
+            return;
+        }
+
+        $default_charset = DBConnection::getDefaultCharset();
+        $default_collation = DBConnection::getDefaultCollation();
+        $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
+
+        $query = "CREATE TABLE `$table` (
+            `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
+            `tickets_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `reservationitems_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `users_id` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `begin` timestamp NULL DEFAULT NULL,
+            `end` timestamp NULL DEFAULT NULL,
+            `status` int NOT NULL DEFAULT '1',
+            `comment_submission` text,
+            `comment_validation` text,
+            `users_id_validate` int {$default_key_sign} NOT NULL DEFAULT '0',
+            `date_creation` timestamp NULL DEFAULT NULL,
+            `date_mod` timestamp NULL DEFAULT NULL,
+            `validation_date` timestamp NULL DEFAULT NULL,
+            PRIMARY KEY (`id`),
+            KEY `tickets_id` (`tickets_id`),
+            KEY `reservationitems_id` (`reservationitems_id`),
+            KEY `users_id` (`users_id`),
+            KEY `status` (`status`),
+            KEY `date_creation` (`date_creation`)
+        ) ENGINE=InnoDB DEFAULT CHARSET={$default_charset} COLLATE={$default_collation} ROW_FORMAT=DYNAMIC;";
+
+        $DB->doQuery($query);
     }
 
     public function uninstall(): bool

--- a/src/Service/InstallManager.php
+++ b/src/Service/InstallManager.php
@@ -65,7 +65,13 @@ final class InstallManager
     private function installTicketReservationRequestsTable(\DBmysql $DB): void
     {
         $table = TicketReservationRequest::getTable();
-        if ($DB->tableExists($table)) {
+        // `tableExists()`'s cache only ever grows (a table once found never
+        // leaves it), it is never invalidated when a table is dropped. Since
+        // `uninstall()` can genuinely drop this table within the same PHP
+        // process (e.g. an uninstall immediately followed by a reinstall),
+        // relying on the cache here could make this guard wrongly believe
+        // the table still exists and skip recreating it. Bypass the cache.
+        if ($DB->tableExists($table, false)) {
             return;
         }
 
@@ -100,8 +106,18 @@ final class InstallManager
 
     public function uninstall(): bool
     {
+        global $DB;
+
         $config = new Config();
         $config->deleteByCriteria(['context' => 'advancedforms']);
+
+        $table = TicketReservationRequest::getTable();
+        // Bypass the cache here too, for the same reason as in
+        // installTicketReservationRequestsTable().
+        if ($DB->tableExists($table, false)) {
+            $DB->dropTable($table);
+        }
+
         return true;
     }
 }

--- a/src/Service/InstallManager.php
+++ b/src/Service/InstallManager.php
@@ -33,6 +33,7 @@
 
 namespace GlpiPlugin\Advancedforms\Service;
 
+use DBmysql;
 use Config;
 use DBConnection;
 use Glpi\Toolbox\SingletonTrait;
@@ -62,7 +63,7 @@ final class InstallManager
         return true;
     }
 
-    private function installTicketReservationRequestsTable(\DBmysql $DB): void
+    private function installTicketReservationRequestsTable(DBmysql $DB): void
     {
         $table = TicketReservationRequest::getTable();
         // `tableExists()`'s cache only ever grows (a table once found never
@@ -79,7 +80,7 @@ final class InstallManager
         $default_collation = DBConnection::getDefaultCollation();
         $default_key_sign = DBConnection::getDefaultPrimaryKeySignOption();
 
-        $query = "CREATE TABLE `$table` (
+        $query = "CREATE TABLE `{$table}` (
             `id` int {$default_key_sign} NOT NULL AUTO_INCREMENT,
             `tickets_id` int {$default_key_sign} NOT NULL DEFAULT '0',
             `reservationitems_id` int {$default_key_sign} NOT NULL DEFAULT '0',

--- a/src/Service/InstallManager.php
+++ b/src/Service/InstallManager.php
@@ -52,12 +52,6 @@ final class InstallManager
 
         $this->installTicketReservationRequestsTable($DB);
 
-        // No addField()/addKey()/... calls are queued on `$migration` yet
-        // (the table above is created with a plain, guarded `CREATE TABLE`),
-        // so this call is currently a no-op. It is kept as a safety net so
-        // that any future schema change added here (e.g. via `addField()`)
-        // is not silently forgotten, matching the convention used by other
-        // GLPI plugins (see `plugins/fields/hook.php`).
         $migration->executeMigration();
 
         return true;
@@ -66,12 +60,7 @@ final class InstallManager
     private function installTicketReservationRequestsTable(DBmysql $DB): void
     {
         $table = TicketReservationRequest::getTable();
-        // `tableExists()`'s cache only ever grows (a table once found never
-        // leaves it), it is never invalidated when a table is dropped. Since
-        // `uninstall()` can genuinely drop this table within the same PHP
-        // process (e.g. an uninstall immediately followed by a reinstall),
-        // relying on the cache here could make this guard wrongly believe
-        // the table still exists and skip recreating it. Bypass the cache.
+
         if ($DB->tableExists($table, false)) {
             return;
         }
@@ -113,8 +102,6 @@ final class InstallManager
         $config->deleteByCriteria(['context' => 'advancedforms']);
 
         $table = TicketReservationRequest::getTable();
-        // Bypass the cache here too, for the same reason as in
-        // installTicketReservationRequestsTable().
         if ($DB->tableExists($table, false)) {
             $DB->dropTable($table);
         }

--- a/src/Service/TimelineManager.php
+++ b/src/Service/TimelineManager.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Service;
+
+use CommonDBTM;
+use CommonITILObject;
+use Glpi\Application\View\TemplateRenderer;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use ReservationItem;
+use Ticket;
+
+/**
+ * Injects `TicketReservationRequest` entries into a `Ticket`'s timeline.
+ *
+ * Registered against `Hooks::TIMELINE_ITEMS` by `InitManager::registerTimelineHooks()`.
+ */
+final class TimelineManager
+{
+    /**
+     * @param array{item: object, timeline: array<string, array<string, mixed>>} $params
+     *        Called by core's `Plugin::doHook(Hooks::TIMELINE_ITEMS, ['item' => $this, 'timeline' => &$timeline])`
+     *        (see `CommonITILObject::getTimelineItems()`). The 'timeline' entry
+     *        of the array holds a genuine PHP reference to the caller's
+     *        `$timeline` variable: mutating `$params['timeline'][...]` here
+     *        is visible to the caller even though `$params` itself is passed
+     *        by value (a copied array preserves references held by its
+     *        elements). The parameter is therefore intentionally NOT declared
+     *        `array &$params`: `Plugin::doHook()` invokes this callback via
+     *        `call_user_func()`, which cannot pass its argument by reference
+     *        to a callee declaring a by-reference parameter (it triggers a
+     *        PHP warning).
+     */
+    public static function addTimelineItems(array $params): void
+    {
+        $ticket = $params['item'] ?? null;
+        if (!$ticket instanceof Ticket) {
+            return;
+        }
+
+        $timeline = &$params['timeline'];
+
+        $request = new TicketReservationRequest();
+
+        // Only the ids are read off `find()`'s raw rows: their static return
+        // type is a generic (unshaped) `array`, so anything read from a row
+        // is reported as `mixed` by phpstan. All actual field values are
+        // instead read back from `$request->fields` after `getFromDB()`.
+        $ids = array_keys($request->find(['tickets_id' => $ticket->getID()]));
+
+        foreach ($ids as $id) {
+            if (!$request->getFromDB($id)) {
+                continue;
+            }
+
+            $reservationitems_id = $request->fields['reservationitems_id'] ?? 0;
+            $reservationitems_id = is_numeric($reservationitems_id) ? (int) $reservationitems_id : 0;
+
+            $content = TemplateRenderer::getInstance()->render('@advancedforms/timeline/reservation_request.html.twig', [
+                'request' => $request->getTimelineInfo(),
+                'equipment_name' => self::getEquipmentName($reservationitems_id),
+            ]);
+
+            $date_creation = $request->fields['date_creation'] ?? null;
+            $users_id = $request->fields['users_id'] ?? 0;
+            $users_id = is_numeric($users_id) ? (int) $users_id : 0;
+
+            $timeline["TicketReservationRequest_{$request->getID()}"] = [
+                'type' => TicketReservationRequest::class,
+                'item' => [
+                    'id' => $request->getID(),
+                    'content' => $content,
+                    'is_content_safe' => true,
+                    'date' => is_string($date_creation) ? $date_creation : null,
+                    'users_id' => $users_id,
+                    'can_edit' => false,
+                    'timeline_position' => CommonITILObject::TIMELINE_LEFT,
+                ],
+                'object' => clone $request,
+            ];
+        }
+    }
+
+    /**
+     * Resolve a human-readable name for the reservable asset behind a
+     * `ReservationItem`, e.g. "Laptop #42". Returns an empty string if the
+     * reservation item or its underlying asset can no longer be found.
+     */
+    private static function getEquipmentName(int $reservationitems_id): string
+    {
+        $reservation_item = new ReservationItem();
+        if (!$reservation_item->getFromDB($reservationitems_id)) {
+            return '';
+        }
+
+        $itemtype = $reservation_item->fields['itemtype'] ?? '';
+        $itemtype = is_string($itemtype) ? $itemtype : '';
+
+        $items_id = $reservation_item->fields['items_id'] ?? 0;
+        $items_id = is_numeric($items_id) ? (int) $items_id : 0;
+
+        $item = getItemForItemtype($itemtype);
+        if (!$item instanceof CommonDBTM || !$item->getFromDB($items_id)) {
+            return '';
+        }
+
+        return $item->getName();
+    }
+}

--- a/src/Service/TimelineManager.php
+++ b/src/Service/TimelineManager.php
@@ -40,26 +40,15 @@ use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use ReservationItem;
 use Ticket;
 
-/**
- * Injects `TicketReservationRequest` entries into a `Ticket`'s timeline.
- *
- * Registered against `Hooks::TIMELINE_ITEMS` by `InitManager::registerTimelineHooks()`.
- */
+/** Injects `TicketReservationRequest` entries into a `Ticket`'s timeline (registered against `Hooks::TIMELINE_ITEMS`). */
 final class TimelineManager
 {
     /**
      * @param array{item: object, timeline: array<string, array<string, mixed>>} $params
-     *        Called by core's `Plugin::doHook(Hooks::TIMELINE_ITEMS, ['item' => $this, 'timeline' => &$timeline])`
-     *        (see `CommonITILObject::getTimelineItems()`). The 'timeline' entry
-     *        of the array holds a genuine PHP reference to the caller's
-     *        `$timeline` variable: mutating `$params['timeline'][...]` here
-     *        is visible to the caller even though `$params` itself is passed
-     *        by value (a copied array preserves references held by its
-     *        elements). The parameter is therefore intentionally NOT declared
-     *        `array &$params`: `Plugin::doHook()` invokes this callback via
-     *        `call_user_func()`, which cannot pass its argument by reference
-     *        to a callee declaring a by-reference parameter (it triggers a
-     *        PHP warning).
+     *        `$params['timeline']` holds a real PHP reference to the caller's array (see
+     *        `CommonITILObject::getTimelineItems()`), which survives being passed here by
+     *        value — do not declare this `array &$params`, `Plugin::doHook()` calls it via
+     *        `call_user_func()`, which warns on by-ref params.
      */
     public static function addTimelineItems(array $params): void
     {
@@ -72,10 +61,7 @@ final class TimelineManager
 
         $request = new TicketReservationRequest();
 
-        // Only the ids are read off `find()`'s raw rows: their static return
-        // type is a generic (unshaped) `array`, so anything read from a row
-        // is reported as `mixed` by phpstan. All actual field values are
-        // instead read back from `$request->fields` after `getFromDB()`.
+        // Only ids come from find(); actual fields are re-read via getFromDB() below.
         $ids = array_keys($request->find(['tickets_id' => $ticket->getID()]));
 
         foreach ($ids as $id) {
@@ -111,11 +97,7 @@ final class TimelineManager
         }
     }
 
-    /**
-     * Resolve a human-readable name for the reservable asset behind a
-     * `ReservationItem`, e.g. "Laptop #42". Returns an empty string if the
-     * reservation item or its underlying asset can no longer be found.
-     */
+    /** Resolves the reservable asset's display name; empty string if it no longer exists. */
     private static function getEquipmentName(int $reservationitems_id): string
     {
         $reservation_item = new ReservationItem();

--- a/src/Service/TimelineManager.php
+++ b/src/Service/TimelineManager.php
@@ -95,7 +95,7 @@ final class TimelineManager
             $users_id = $request->fields['users_id'] ?? 0;
             $users_id = is_numeric($users_id) ? (int) $users_id : 0;
 
-            $timeline["TicketReservationRequest_{$request->getID()}"] = [
+            $timeline['TicketReservationRequest_' . $request->getID()] = [
                 'type' => TicketReservationRequest::class,
                 'item' => [
                     'id' => $request->getID(),

--- a/src/Service/TimelineManager.php
+++ b/src/Service/TimelineManager.php
@@ -33,11 +33,9 @@
 
 namespace GlpiPlugin\Advancedforms\Service;
 
-use CommonDBTM;
 use CommonITILObject;
 use Glpi\Application\View\TemplateRenderer;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
-use ReservationItem;
 use Ticket;
 
 /** Injects `TicketReservationRequest` entries into a `Ticket`'s timeline (registered against `Hooks::TIMELINE_ITEMS`). */
@@ -61,20 +59,20 @@ final class TimelineManager
 
         $request = new TicketReservationRequest();
 
-        // Only ids come from find(); actual fields are re-read via getFromDB() below.
-        $ids = array_keys($request->find(['tickets_id' => $ticket->getID()]));
-
-        foreach ($ids as $id) {
-            if (!$request->getFromDB($id)) {
+        foreach ($request->find(['tickets_id' => $ticket->getID()]) as $row) {
+            if (!is_array($row)) {
                 continue;
             }
+
+            // find() already returns the full row; hydrate in place, no extra query.
+            $request->getFromResultSet($row);
 
             $reservationitems_id = $request->fields['reservationitems_id'] ?? 0;
             $reservationitems_id = is_numeric($reservationitems_id) ? (int) $reservationitems_id : 0;
 
             $content = TemplateRenderer::getInstance()->render('@advancedforms/timeline/reservation_request.html.twig', [
                 'request' => $request->getTimelineInfo(),
-                'equipment_name' => self::getEquipmentName($reservationitems_id),
+                'equipment_name' => TicketReservationRequest::getReservableItemName($reservationitems_id),
             ]);
 
             $date_creation = $request->fields['date_creation'] ?? null;
@@ -95,27 +93,5 @@ final class TimelineManager
                 'object' => clone $request,
             ];
         }
-    }
-
-    /** Resolves the reservable asset's display name; empty string if it no longer exists. */
-    private static function getEquipmentName(int $reservationitems_id): string
-    {
-        $reservation_item = new ReservationItem();
-        if (!$reservation_item->getFromDB($reservationitems_id)) {
-            return '';
-        }
-
-        $itemtype = $reservation_item->fields['itemtype'] ?? '';
-        $itemtype = is_string($itemtype) ? $itemtype : '';
-
-        $items_id = $reservation_item->fields['items_id'] ?? 0;
-        $items_id = is_numeric($items_id) ? (int) $items_id : 0;
-
-        $item = getItemForItemtype($itemtype);
-        if (!$item instanceof CommonDBTM || !$item->getFromDB($items_id)) {
-            return '';
-        }
-
-        return $item->getName();
     }
 }

--- a/templates/destination/prereservation_config_field.html.twig
+++ b/templates/destination/prereservation_config_field.html.twig
@@ -31,22 +31,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_FROM_SPECIFIC_QUESTION }}">
-    {{ fields.dropdownArrayField(
-        question_extra_field.input_name,
-        question_extra_field.value,
-        question_extra_field.possible_values,
-        "",
-        options|merge({
-            field_class: '',
-            mb: '',
-            no_label: true,
-            display_emptychoice: true,
-            emptylabel: question_extra_field.empty_label,
-            aria_label: question_extra_field.empty_label,
-        })
-    ) }}
-
+{% macro require_approval_toggle(require_approval_extra_field) %}
     <label class="col form-check form-switch mt-3 mb-0">
         <input
             name="{{ require_approval_extra_field.input_name }}"
@@ -62,4 +47,35 @@
         >
         <span class="form-check-label">{{ __('Require technician approval', 'advancedforms') }}</span>
     </label>
+{% endmacro %}
+
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_SPECIFIC_ANSWER }}">
+    {{ fields.dropdownArrayField(
+        question_extra_field.input_name,
+        question_extra_field.value,
+        question_extra_field.possible_values,
+        "",
+        options|merge({
+            field_class: '',
+            mb: '',
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: question_extra_field.empty_label,
+            aria_label: question_extra_field.empty_label,
+        })
+    ) }}
+
+    {{ _self.require_approval_toggle(require_approval_extra_field) }}
+</div>
+
+{# Same toggle as above: relevant to every strategy that actually creates a
+   pre-reservation, not only "specific answer". The display-condition
+   mechanism only matches a single value, so the field is duplicated per
+   strategy rather than shown unconditionally (irrelevant for "No pre-reservation"). #}
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_LAST_VALID_ANSWER }}">
+    {{ _self.require_approval_toggle(require_approval_extra_field) }}
+</div>
+
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_ALL_VALID_ANSWERS }}">
+    {{ _self.require_approval_toggle(require_approval_extra_field) }}
 </div>

--- a/templates/destination/prereservation_config_field.html.twig
+++ b/templates/destination/prereservation_config_field.html.twig
@@ -1,0 +1,66 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+{# The strategy dropdown itself is already rendered by the generic
+   destination field wrapper (form_destination_commonitil_config.html.twig).
+   This template only renders the additional fields shown when the
+   FROM_SPECIFIC_QUESTION strategy is selected: it relies on the same
+   `data-glpi-itildestination-field-config-display-condition` convention used
+   by core fields (e.g. UrgencyField) to be shown/hidden automatically. #}
+<div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_FROM_SPECIFIC_QUESTION }}">
+    {{ fields.dropdownArrayField(
+        question_extra_field.input_name,
+        question_extra_field.value,
+        question_extra_field.possible_values,
+        "",
+        options|merge({
+            field_class: '',
+            mb: '',
+            no_label: true,
+            display_emptychoice: true,
+            emptylabel: question_extra_field.empty_label,
+            aria_label: question_extra_field.empty_label,
+        })
+    ) }}
+
+    {{ fields.checkboxField(
+        require_approval_extra_field.input_name,
+        require_approval_extra_field.value,
+        __('Require technician approval', 'advancedforms'),
+        options|merge({
+            field_class: '',
+            mb: '',
+            no_label: true,
+        })
+    ) }}
+</div>

--- a/templates/destination/prereservation_config_field.html.twig
+++ b/templates/destination/prereservation_config_field.html.twig
@@ -31,12 +31,6 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-{# The strategy dropdown itself is already rendered by the generic
-   destination field wrapper (form_destination_commonitil_config.html.twig).
-   This template only renders the additional fields shown when the
-   FROM_SPECIFIC_QUESTION strategy is selected: it relies on the same
-   `data-glpi-itildestination-field-config-display-condition` convention used
-   by core fields (e.g. UrgencyField) to be shown/hidden automatically. #}
 <div data-glpi-itildestination-field-config-display-condition="{{ CONFIG_FROM_SPECIFIC_QUESTION }}">
     {{ fields.dropdownArrayField(
         question_extra_field.input_name,
@@ -53,14 +47,19 @@
         })
     ) }}
 
-    {{ fields.checkboxField(
-        require_approval_extra_field.input_name,
-        require_approval_extra_field.value,
-        __('Require technician approval', 'advancedforms'),
-        options|merge({
-            field_class: '',
-            mb: '',
-            no_label: true,
-        })
-    ) }}
+    <label class="col form-check form-switch mt-3 mb-0">
+        <input
+            name="{{ require_approval_extra_field.input_name }}"
+            type="hidden"
+            value="0"
+        >
+        <input
+            name="{{ require_approval_extra_field.input_name }}"
+            class="form-check-input"
+            type="checkbox"
+            value="1"
+            {{ require_approval_extra_field.value ? 'checked' : '' }}
+        >
+        <span class="form-check-label">{{ __('Require technician approval', 'advancedforms') }}</span>
+    </label>
 </div>

--- a/templates/editor/question_types/reservation_config.html.twig
+++ b/templates/editor/question_types/reservation_config.html.twig
@@ -50,4 +50,11 @@
             'init'               : question is not null ? true : false,
         }
     ) }}
+
+    <div class="alert alert-info mt-2 mb-0">
+        <div>
+            {{ __('Whether a technician must approve the reservation before it is confirmed is configured on the destination that uses this question, under', 'advancedforms') }}
+            <code>{{ destination_label }} &gt; {{ timeline_category_label }} &gt; {{ pre_reservation_label }}</code>.
+        </div>
+    </div>
 </div>

--- a/templates/editor/question_types/reservation_config.html.twig
+++ b/templates/editor/question_types/reservation_config.html.twig
@@ -1,0 +1,53 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
+<div
+    class="mt-n1 mb-3"
+    data-glpi-form-editor-question-extra-details
+>
+    {{ fields.dropdownArrayField(
+        'extra_data[' ~ ALLOWED_ITEMTYPES ~ ']',
+        '',
+        reservation_types,
+        __('Allowed equipment types', 'advancedforms'),
+        {
+            'values'             : extra_data.getAllowedItemtypes(),
+            'multiple'           : true,
+            'display_emptychoice': true,
+            'emptylabel'         : __('All reservable types', 'advancedforms'),
+            'full_width'         : true,
+            'is_horizontal'      : false,
+            'init'               : question is not null ? true : false,
+        }
+    ) }}
+</div>

--- a/templates/reservation_question.html.twig
+++ b/templates/reservation_question.html.twig
@@ -72,7 +72,7 @@
     <input type="hidden" name="{{ input_name }}[reservationitems_id]" data-reservation-question-field="reservationitems_id">
 </div>
 <script type="module">
-    import { ReservationQuestionWidget } from '/plugins/advancedforms/js/modules/ReservationQuestionWidget.js';
+    import { ReservationQuestionWidget } from '/plugins/advancedforms/js/modules/ReservationQuestionWidget.js?v={{ constant('PLUGIN_ADVANCEDFORMS_VERSION') }}';
     $(function() {
         new ReservationQuestionWidget(
             document.querySelector('[data-reservation-question-widget][data-input-name="{{ input_name|e('js') }}"]')

--- a/templates/reservation_question.html.twig
+++ b/templates/reservation_question.html.twig
@@ -29,6 +29,8 @@
  # -------------------------------------------------------------------------
  #}
 
+{% import 'components/form/fields_macros.html.twig' as fields %}
+
 <div class="reservation-question-widget"
      data-reservation-question-widget
      data-input-name="{{ input_name }}"
@@ -38,33 +40,35 @@
         <option value=""></option>
     </select>
 
-    <div class="reservation-question-dates d-none mt-2" data-reservation-question-dates>
-        <div class="row g-2">
-            <div class="col-12 col-sm-6">
-                <input
-                    type="text"
-                    class="form-control"
-                    placeholder="{{ __('Start date', 'advancedforms') }}"
-                    aria-label="{{ __('Start date', 'advancedforms') }}"
-                    data-reservation-question-begin-picker
-                >
-            </div>
-            <div class="col-12 col-sm-6">
-                <input
-                    type="text"
-                    class="form-control"
-                    placeholder="{{ __('End date', 'advancedforms') }}"
-                    aria-label="{{ __('End date', 'advancedforms') }}"
-                    data-reservation-question-end-picker
-                >
-            </div>
+    <div class="reservation-question-dates row g-2 mt-2 d-none" data-reservation-question-dates>
+        <div class="col-12 col-sm-6">
+            {{ fields.datetimeField(
+                input_name ~ '[begin]',
+                '',
+                __('Start date', 'advancedforms'),
+                {
+                    is_horizontal: false,
+                    full_width: true,
+                    additional_attributes: {'data-reservation-question-begin-picker': ''},
+                }
+            ) }}
         </div>
-        <div class="mt-1 small" data-reservation-question-availability></div>
+        <div class="col-12 col-sm-6">
+            {{ fields.datetimeField(
+                input_name ~ '[end]',
+                '',
+                __('End date', 'advancedforms'),
+                {
+                    is_horizontal: false,
+                    full_width: true,
+                    additional_attributes: {'data-reservation-question-end-picker': ''},
+                }
+            ) }}
+        </div>
+        <div class="col-12 mt-1 small" data-reservation-question-availability></div>
     </div>
 
     <input type="hidden" name="{{ input_name }}[reservationitems_id]" data-reservation-question-field="reservationitems_id">
-    <input type="hidden" name="{{ input_name }}[begin]" data-reservation-question-field="begin">
-    <input type="hidden" name="{{ input_name }}[end]" data-reservation-question-field="end">
 </div>
 <script type="module">
     import { ReservationQuestionWidget } from '/plugins/advancedforms/js/modules/ReservationQuestionWidget.js';

--- a/templates/reservation_question.html.twig
+++ b/templates/reservation_question.html.twig
@@ -66,6 +66,7 @@
             ) }}
         </div>
         <div class="col-12 mt-1 small" data-reservation-question-availability></div>
+        <div class="col-12 mt-1" data-reservation-question-reservations></div>
     </div>
 
     <input type="hidden" name="{{ input_name }}[reservationitems_id]" data-reservation-question-field="reservationitems_id">

--- a/templates/reservation_question.html.twig
+++ b/templates/reservation_question.html.twig
@@ -1,0 +1,76 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+<div class="reservation-question-widget"
+     data-reservation-question-widget
+     data-input-name="{{ input_name }}"
+     data-allowed-itemtypes="{{ allowed_itemtypes|json_encode }}"
+>
+    <select class="form-select" data-reservation-question-item-select>
+        <option value=""></option>
+    </select>
+
+    <div class="reservation-question-dates d-none mt-2" data-reservation-question-dates>
+        <div class="row g-2">
+            <div class="col-12 col-sm-6">
+                <input
+                    type="text"
+                    class="form-control"
+                    placeholder="{{ __('Start date', 'advancedforms') }}"
+                    aria-label="{{ __('Start date', 'advancedforms') }}"
+                    data-reservation-question-begin-picker
+                >
+            </div>
+            <div class="col-12 col-sm-6">
+                <input
+                    type="text"
+                    class="form-control"
+                    placeholder="{{ __('End date', 'advancedforms') }}"
+                    aria-label="{{ __('End date', 'advancedforms') }}"
+                    data-reservation-question-end-picker
+                >
+            </div>
+        </div>
+        <div class="mt-1 small" data-reservation-question-availability></div>
+    </div>
+
+    <input type="hidden" name="{{ input_name }}[reservationitems_id]" data-reservation-question-field="reservationitems_id">
+    <input type="hidden" name="{{ input_name }}[begin]" data-reservation-question-field="begin">
+    <input type="hidden" name="{{ input_name }}[end]" data-reservation-question-field="end">
+</div>
+<script type="module">
+    import { ReservationQuestionWidget } from '/plugins/advancedforms/js/modules/ReservationQuestionWidget.js';
+    $(function() {
+        new ReservationQuestionWidget(
+            document.querySelector('[data-reservation-question-widget][data-input-name="{{ input_name|e('js') }}"]')
+        );
+    });
+</script>

--- a/templates/timeline/reservation_request.html.twig
+++ b/templates/timeline/reservation_request.html.twig
@@ -44,30 +44,33 @@
 } %}
 
 <div class="reservation-request-timeline-item" data-reservation-request-id="{{ request.id }}">
-    <div class="d-flex align-items-center gap-2 mb-1">
-        <i class="ti ti-calendar-event"></i>
-        <span class="fw-bold">{{ equipment_name|default('') }}</span>
-        <span class="badge bg-{{ status_classes[request.status]|default('secondary') }}">
+    <div class="d-flex align-items-center gap-2 mb-2">
+        <i class="ti ti-calendar-event fs-4 text-muted"></i>
+        <div class="flex-grow-1">
+            <div class="fw-bold">{{ equipment_name|default('') }}</div>
+            <div class="text-muted small">
+                <i class="ti ti-clock me-1"></i>{{ request.begin }} &rarr; {{ request.end }}
+            </div>
+        </div>
+        <span class="badge bg-{{ status_classes[request.status]|default('secondary') }}-lt">
             {{ status_labels[request.status]|default(request.status) }}
         </span>
     </div>
 
-    <div class="reservation-request-slot">
-        {{ request.begin }} &rarr; {{ request.end }}
-    </div>
-
     {% if request.is_direct_reservation %}
-        <div class="text-muted small mt-1">
-            <i class="ti ti-circle-check me-1"></i>{{ __('Reservation confirmed automatically', 'advancedforms') }}
+        <div class="d-flex align-items-center gap-2 text-success small mb-2">
+            <i class="ti ti-circle-check"></i>
+            <span>{{ __('Reservation confirmed automatically', 'advancedforms') }}</span>
         </div>
     {% elseif request.status == constant(request_class ~ '::STATUS_CANCELED') %}
-        <div class="text-muted small mt-1">
-            {{ __('This slot is no longer available. Please submit a new reservation request.', 'advancedforms') }}
+        <div class="d-flex align-items-center gap-2 text-muted small mb-2">
+            <i class="ti ti-alert-triangle"></i>
+            <span>{{ __('This slot is no longer available. Please submit a new reservation request.', 'advancedforms') }}</span>
         </div>
     {% endif %}
 
     {% if request.comment_validation is not empty %}
-        <div class="reservation-request-comment mt-1">
+        <div class="reservation-request-comment border-start border-3 ps-2 text-muted small mb-2">
             {{ request.comment_validation }}
         </div>
     {% endif %}

--- a/templates/timeline/reservation_request.html.twig
+++ b/templates/timeline/reservation_request.html.twig
@@ -105,7 +105,7 @@
             </div>
         </form>
         <script type="module">
-            import { ReservationRequestTimelineActions } from '/plugins/advancedforms/js/modules/ReservationRequestTimelineActions.js';
+            import { ReservationRequestTimelineActions } from '/plugins/advancedforms/js/modules/ReservationRequestTimelineActions.js?v={{ constant('PLUGIN_ADVANCEDFORMS_VERSION') }}';
             $(function() {
                 new ReservationRequestTimelineActions(
                     document.querySelector('[data-reservation-request-id="{{ request.id }}"]')

--- a/templates/timeline/reservation_request.html.twig
+++ b/templates/timeline/reservation_request.html.twig
@@ -1,0 +1,105 @@
+{#
+ # -------------------------------------------------------------------------
+ # advancedforms plugin for GLPI
+ # -------------------------------------------------------------------------
+ #
+ # MIT License
+ #
+ # Permission is hereby granted, free of charge, to any person obtaining a copy
+ # of this software and associated documentation files (the "Software"), to deal
+ # in the Software without restriction, including without limitation the rights
+ # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ # copies of the Software, and to permit persons to whom the Software is
+ # furnished to do so, subject to the following conditions:
+ #
+ # The above copyright notice and this permission notice shall be included in all
+ # copies or substantial portions of the Software.
+ #
+ # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ # SOFTWARE.
+ # -------------------------------------------------------------------------
+ # @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ # @license   MIT https://opensource.org/licenses/mit-license.php
+ # @link      https://github.com/pluginsGLPI/advancedforms
+ # -------------------------------------------------------------------------
+ #}
+
+{% set request_class = 'GlpiPlugin\\Advancedforms\\Model\\TicketReservationRequest' %}
+{% set status_classes = {
+    (constant(request_class ~ '::STATUS_WAITING')): 'warning',
+    (constant(request_class ~ '::STATUS_ACCEPTED')): 'success',
+    (constant(request_class ~ '::STATUS_REFUSED')): 'danger',
+    (constant(request_class ~ '::STATUS_CANCELED')): 'secondary',
+} %}
+{% set status_labels = {
+    (constant(request_class ~ '::STATUS_WAITING')): __('Pending validation', 'advancedforms'),
+    (constant(request_class ~ '::STATUS_ACCEPTED')): __('Approved', 'advancedforms'),
+    (constant(request_class ~ '::STATUS_REFUSED')): __('Refused', 'advancedforms'),
+    (constant(request_class ~ '::STATUS_CANCELED')): __('Canceled', 'advancedforms'),
+} %}
+
+<div class="reservation-request-timeline-item" data-reservation-request-id="{{ request.id }}">
+    <div class="d-flex align-items-center gap-2 mb-1">
+        <i class="ti ti-calendar-event"></i>
+        <span class="fw-bold">{{ equipment_name|default('') }}</span>
+        <span class="badge bg-{{ status_classes[request.status]|default('secondary') }}">
+            {{ status_labels[request.status]|default(request.status) }}
+        </span>
+    </div>
+
+    <div class="reservation-request-slot">
+        {{ request.begin }} &rarr; {{ request.end }}
+    </div>
+
+    {% if request.is_direct_reservation %}
+        <div class="text-muted small mt-1">
+            <i class="ti ti-circle-check me-1"></i>{{ __('Reservation confirmed automatically', 'advancedforms') }}
+        </div>
+    {% elseif request.status == constant(request_class ~ '::STATUS_CANCELED') %}
+        <div class="text-muted small mt-1">
+            {{ __('This slot is no longer available. Please submit a new reservation request.', 'advancedforms') }}
+        </div>
+    {% endif %}
+
+    {% if request.comment_validation is not empty %}
+        <div class="reservation-request-comment mt-1">
+            {{ request.comment_validation }}
+        </div>
+    {% endif %}
+
+    {% if request.can_answer %}
+        <form class="reservation-request-answer-form mt-2" data-reservation-request-form>
+            <div class="mb-2">
+                <textarea
+                    class="form-control"
+                    name="comment"
+                    placeholder="{{ __('Comment (optional)', 'advancedforms') }}"
+                    data-reservation-request-comment
+                ></textarea>
+            </div>
+            <div class="d-flex gap-2">
+                <button
+                    type="button"
+                    class="btn btn-sm btn-success"
+                    data-reservation-request-id="{{ request.id }}"
+                    data-reservation-request-action="approve"
+                >
+                    <i class="ti ti-check me-1"></i>{{ __('Approve', 'advancedforms') }}
+                </button>
+                <button
+                    type="button"
+                    class="btn btn-sm btn-danger"
+                    data-reservation-request-id="{{ request.id }}"
+                    data-reservation-request-action="refuse"
+                >
+                    <i class="ti ti-x me-1"></i>{{ __('Refuse', 'advancedforms') }}
+                </button>
+            </div>
+        </form>
+    {% endif %}
+</div>

--- a/templates/timeline/reservation_request.html.twig
+++ b/templates/timeline/reservation_request.html.twig
@@ -101,5 +101,13 @@
                 </button>
             </div>
         </form>
+        <script type="module">
+            import { ReservationRequestTimelineActions } from '/plugins/advancedforms/js/modules/ReservationRequestTimelineActions.js';
+            $(function() {
+                new ReservationRequestTimelineActions(
+                    document.querySelector('[data-reservation-request-id="{{ request.id }}"]')
+                );
+            });
+        </script>
     {% endif %}
 </div>

--- a/tests/Controller/CheckAvailabilityControllerTest.php
+++ b/tests/Controller/CheckAvailabilityControllerTest.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Controller;
+
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use GlpiPlugin\Advancedforms\Controller\CheckAvailabilityController;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Reservation;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+
+final class CheckAvailabilityControllerTest extends AdvancedFormsTestCase
+{
+    public function testAccessDeniedWithoutRights(): void
+    {
+        $this->login();
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+
+        $controller = new CheckAvailabilityController();
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller(Request::create('/', 'POST', []));
+    }
+
+    public function testMissingParamsThrowsBadRequest(): void
+    {
+        $this->login();
+        $controller = new CheckAvailabilityController();
+        $this->expectException(BadRequestHttpException::class);
+        $controller(Request::create('/', 'POST', []));
+    }
+
+    public function testAvailableSlotReturnsTrue(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $controller = new CheckAvailabilityController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 09:00:00',
+            'end' => '2026-02-01 10:00:00',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['available' => true], json_decode((string) $response->getContent(), true));
+    }
+
+    public function testConflictingSlotReturnsFalse(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 09:00:00',
+            'end' => '2026-02-01 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        $controller = new CheckAvailabilityController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 10:00:00', // overlaps
+            'end' => '2026-02-01 12:00:00',
+        ]));
+
+        $this->assertSame(['available' => false], json_decode((string) $response->getContent(), true));
+    }
+
+    public function testBackToBackSlotIsAvailable(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 09:00:00',
+            'end' => '2026-02-01 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        $controller = new CheckAvailabilityController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 11:00:00', // starts exactly when the other ends: no overlap
+            'end' => '2026-02-01 12:00:00',
+        ]));
+
+        $this->assertSame(['available' => true], json_decode((string) $response->getContent(), true));
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
+        return $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}

--- a/tests/Controller/CheckAvailabilityControllerTest.php
+++ b/tests/Controller/CheckAvailabilityControllerTest.php
@@ -128,7 +128,10 @@ final class CheckAvailabilityControllerTest extends AdvancedFormsTestCase
 
     private function getReservableItem(): ReservationItem
     {
-        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
+        $computer = $this->createItem('Computer', [
+            'name' => 'test-computer',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
         return $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer->getID(),

--- a/tests/Controller/GetReservationsControllerTest.php
+++ b/tests/Controller/GetReservationsControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Controller;
+
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use GlpiPlugin\Advancedforms\Controller\GetReservationsController;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Reservation;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+
+final class GetReservationsControllerTest extends AdvancedFormsTestCase
+{
+    public function testAccessDeniedWithoutRights(): void
+    {
+        $this->login();
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+
+        $controller = new GetReservationsController();
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller(Request::create('/', 'POST', []));
+    }
+
+    public function testMissingParamsThrowsBadRequest(): void
+    {
+        $this->login();
+        $controller = new GetReservationsController();
+        $this->expectException(BadRequestHttpException::class);
+        $controller(Request::create('/', 'POST', []));
+    }
+
+    public function testReturnsReservationsForItem(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 09:00:00',
+            'end' => '2026-02-01 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+            'comment' => 'this should not leak',
+        ]));
+
+        $controller = new GetReservationsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+        $this->assertSame('2026-02-01 09:00:00', $data[0]['begin']);
+        $this->assertSame('2026-02-01 11:00:00', $data[0]['end']);
+        $this->assertSame(Session::getLoginUserID(), $data[0]['users_id']);
+        $this->assertArrayNotHasKey('comment', $data[0]);
+    }
+
+    public function testReturnsEmptyArrayWhenNoReservations(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $controller = new GetReservationsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+        ]));
+
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertSame([], $data);
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', ['name' => 'test-computer-resa', 'entities_id' => 0]);
+        return $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}

--- a/tests/Controller/GetReservationsControllerTest.php
+++ b/tests/Controller/GetReservationsControllerTest.php
@@ -91,6 +91,42 @@ final class GetReservationsControllerTest extends AdvancedFormsTestCase
         $this->assertArrayNotHasKey('comment', $data[0]);
     }
 
+    public function testFiltersReservationsByDateRange(): void
+    {
+        $this->login();
+        $item = $this->getReservableItem();
+
+        $reservation_in_range = new Reservation();
+        $this->assertGreaterThan(0, $reservation_in_range->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 09:00:00',
+            'end' => '2026-02-01 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+        ]));
+
+        $reservation_out_of_range = new Reservation();
+        $this->assertGreaterThan(0, $reservation_out_of_range->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-02 09:00:00',
+            'end' => '2026-02-02 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+        ]));
+
+        $controller = new GetReservationsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-02-01 00:00:00',
+            'end' => '2026-02-01 23:59:59',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+        $this->assertCount(1, $data);
+        $this->assertSame('2026-02-01 09:00:00', $data[0]['begin']);
+        $this->assertSame('2026-02-01 11:00:00', $data[0]['end']);
+    }
+
     public function testReturnsEmptyArrayWhenNoReservations(): void
     {
         $this->login();

--- a/tests/Controller/GetReservationsControllerTest.php
+++ b/tests/Controller/GetReservationsControllerTest.php
@@ -67,11 +67,16 @@ final class GetReservationsControllerTest extends AdvancedFormsTestCase
         $this->login();
         $item = $this->getReservableItem();
 
+        // Without a lower bound, only current/future slots are returned: use a
+        // future date rather than a fixed past one.
+        $begin = date('Y-m-d H:i:s', strtotime('+1 day 09:00:00'));
+        $end = date('Y-m-d H:i:s', strtotime('+1 day 11:00:00'));
+
         $reservation = new Reservation();
         $this->assertGreaterThan(0, $reservation->add([
             'reservationitems_id' => $item->getID(),
-            'begin' => '2026-02-01 09:00:00',
-            'end' => '2026-02-01 11:00:00',
+            'begin' => $begin,
+            'end' => $end,
             'users_id' => Session::getLoginUserID(),
             'comment' => 'this should not leak',
         ]));
@@ -85,9 +90,9 @@ final class GetReservationsControllerTest extends AdvancedFormsTestCase
         $data = json_decode((string) $response->getContent(), true);
         $this->assertIsArray($data);
         $this->assertCount(1, $data);
-        $this->assertSame('2026-02-01 09:00:00', $data[0]['begin']);
-        $this->assertSame('2026-02-01 11:00:00', $data[0]['end']);
-        $this->assertSame(Session::getLoginUserID(), $data[0]['users_id']);
+        $this->assertSame($begin, $data[0]['begin']);
+        $this->assertSame($end, $data[0]['end']);
+        $this->assertArrayNotHasKey('users_id', $data[0]);
         $this->assertArrayNotHasKey('comment', $data[0]);
     }
 
@@ -143,7 +148,10 @@ final class GetReservationsControllerTest extends AdvancedFormsTestCase
 
     private function getReservableItem(): ReservationItem
     {
-        $computer = $this->createItem('Computer', ['name' => 'test-computer-resa', 'entities_id' => 0]);
+        $computer = $this->createItem('Computer', [
+            'name' => 'test-computer-resa',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
         return $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer->getID(),

--- a/tests/Controller/ReservableItemsControllerTest.php
+++ b/tests/Controller/ReservableItemsControllerTest.php
@@ -54,7 +54,7 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
     {
         $this->login();
 
-        $computer = $this->createItem('Computer', ['name' => 'test-reservable-computer', 'entities_id' => 0]);
+        $computer = $this->createItem('Computer', ['name' => 'test-reservable-computer', 'entities_id' => $this->getTestRootEntity(true)]);
         $res_item = $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer->getID(),
@@ -62,7 +62,7 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
         ]);
 
         // Item of an itemtype not in the allowed list must not be returned
-        $monitor = $this->createItem('Monitor', ['name' => 'test-reservable-monitor', 'entities_id' => 0]);
+        $monitor = $this->createItem('Monitor', ['name' => 'test-reservable-monitor', 'entities_id' => $this->getTestRootEntity(true)]);
         $this->createItem('ReservationItem', [
             'itemtype' => 'Monitor',
             'items_id' => $monitor->getID(),
@@ -90,7 +90,7 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
     {
         $this->login();
 
-        $computer = $this->createItem('Computer', ['name' => 'test-inactive-computer', 'entities_id' => 0]);
+        $computer = $this->createItem('Computer', ['name' => 'test-inactive-computer', 'entities_id' => $this->getTestRootEntity(true)]);
         $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer->getID(),
@@ -116,7 +116,7 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
         $CFG_GLPI['reservation_types'] = ['Computer'];
 
         try {
-            $computer = $this->createItem('Computer', ['name' => 'test-fallback-computer', 'entities_id' => 0]);
+            $computer = $this->createItem('Computer', ['name' => 'test-fallback-computer', 'entities_id' => $this->getTestRootEntity(true)]);
             $res_item = $this->createItem('ReservationItem', [
                 'itemtype' => 'Computer',
                 'items_id' => $computer->getID(),
@@ -145,14 +145,14 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
     {
         $this->login();
 
-        $computer1 = $this->createItem('Computer', ['name' => 'alpha-computer', 'entities_id' => 0]);
+        $computer1 = $this->createItem('Computer', ['name' => 'alpha-computer', 'entities_id' => $this->getTestRootEntity(true)]);
         $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer1->getID(),
             'is_active' => 1,
         ]);
 
-        $computer2 = $this->createItem('Computer', ['name' => 'beta-computer', 'entities_id' => 0]);
+        $computer2 = $this->createItem('Computer', ['name' => 'beta-computer', 'entities_id' => $this->getTestRootEntity(true)]);
         $this->createItem('ReservationItem', [
             'itemtype' => 'Computer',
             'items_id' => $computer2->getID(),

--- a/tests/Controller/ReservableItemsControllerTest.php
+++ b/tests/Controller/ReservableItemsControllerTest.php
@@ -107,6 +107,40 @@ final class ReservableItemsControllerTest extends AdvancedFormsTestCase
         $this->assertNotContains('test-inactive-computer (Computer)', $names);
     }
 
+    public function testFallsBackToConfigReservationTypesWhenAllowedItemtypesOmitted(): void
+    {
+        $this->login();
+
+        global $CFG_GLPI;
+        $original_reservation_types = $CFG_GLPI['reservation_types'] ?? null;
+        $CFG_GLPI['reservation_types'] = ['Computer'];
+
+        try {
+            $computer = $this->createItem('Computer', ['name' => 'test-fallback-computer', 'entities_id' => 0]);
+            $res_item = $this->createItem('ReservationItem', [
+                'itemtype' => 'Computer',
+                'items_id' => $computer->getID(),
+                'is_active' => 1,
+            ]);
+
+            $controller = new ReservableItemsController();
+            $response = $controller(Request::create('/', 'POST', []));
+
+            $this->assertSame(200, $response->getStatusCode());
+            $data = json_decode((string) $response->getContent(), true);
+            $this->assertIsArray($data);
+
+            $ids = array_column($data, 'id');
+            $this->assertContains($res_item->getID(), $ids);
+
+            foreach ($data as $row) {
+                $this->assertSame('Computer', $row['itemtype']);
+            }
+        } finally {
+            $CFG_GLPI['reservation_types'] = $original_reservation_types;
+        }
+    }
+
     public function testSearchFiltersResults(): void
     {
         $this->login();

--- a/tests/Controller/ReservableItemsControllerTest.php
+++ b/tests/Controller/ReservableItemsControllerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Controller;
+
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use GlpiPlugin\Advancedforms\Controller\ReservableItemsController;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReservableItemsControllerTest extends AdvancedFormsTestCase
+{
+    public function testAccessDeniedWithoutRights(): void
+    {
+        $this->login();
+        $_SESSION['glpiactiveprofile']['reservation'] = 0;
+
+        $controller = new ReservableItemsController();
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller(Request::create('/', 'POST', []));
+    }
+
+    public function testReturnsActiveReservableItemsFilteredByAllowedItemtypes(): void
+    {
+        $this->login();
+
+        $computer = $this->createItem('Computer', ['name' => 'test-reservable-computer', 'entities_id' => 0]);
+        $res_item = $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+
+        // Item of an itemtype not in the allowed list must not be returned
+        $monitor = $this->createItem('Monitor', ['name' => 'test-reservable-monitor', 'entities_id' => 0]);
+        $this->createItem('ReservationItem', [
+            'itemtype' => 'Monitor',
+            'items_id' => $monitor->getID(),
+            'is_active' => 1,
+        ]);
+
+        $controller = new ReservableItemsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'allowed_itemtypes' => ['Computer'],
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $data = json_decode((string) $response->getContent(), true);
+        $this->assertIsArray($data);
+
+        $ids = array_column($data, 'id');
+        $this->assertContains($res_item->getID(), $ids);
+        foreach ($data as $row) {
+            $this->assertSame('Computer', $row['itemtype']);
+            $this->assertSame('test-reservable-computer (Computer)', $row['text']);
+        }
+    }
+
+    public function testInactiveItemIsExcluded(): void
+    {
+        $this->login();
+
+        $computer = $this->createItem('Computer', ['name' => 'test-inactive-computer', 'entities_id' => 0]);
+        $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 0,
+        ]);
+
+        $controller = new ReservableItemsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'allowed_itemtypes' => ['Computer'],
+        ]));
+
+        $data = json_decode((string) $response->getContent(), true);
+        $names = array_column($data, 'text');
+        $this->assertNotContains('test-inactive-computer (Computer)', $names);
+    }
+
+    public function testSearchFiltersResults(): void
+    {
+        $this->login();
+
+        $computer1 = $this->createItem('Computer', ['name' => 'alpha-computer', 'entities_id' => 0]);
+        $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer1->getID(),
+            'is_active' => 1,
+        ]);
+
+        $computer2 = $this->createItem('Computer', ['name' => 'beta-computer', 'entities_id' => 0]);
+        $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer2->getID(),
+            'is_active' => 1,
+        ]);
+
+        $controller = new ReservableItemsController();
+        $response = $controller(Request::create('/', 'POST', [
+            'allowed_itemtypes' => ['Computer'],
+            'search' => 'alpha',
+        ]));
+
+        $data = json_decode((string) $response->getContent(), true);
+        $names = array_column($data, 'text');
+        $this->assertContains('alpha-computer (Computer)', $names);
+        $this->assertNotContains('beta-computer (Computer)', $names);
+    }
+}

--- a/tests/Controller/ReservationRequestControllerTest.php
+++ b/tests/Controller/ReservationRequestControllerTest.php
@@ -1,0 +1,213 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Controller;
+
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Exception\Http\BadRequestHttpException;
+use GlpiPlugin\Advancedforms\Controller\ReservationRequestController;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Reservation;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ReservationRequestControllerTest extends AdvancedFormsTestCase
+{
+    public function testMissingIdThrowsBadRequest(): void
+    {
+        $this->login();
+
+        $controller = new ReservationRequestController();
+        $this->expectException(BadRequestHttpException::class);
+        $controller(Request::create('/', 'POST', ['action' => 'approve']));
+    }
+
+    public function testInvalidActionThrowsBadRequest(): void
+    {
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        $controller = new ReservationRequestController();
+        $this->expectException(BadRequestHttpException::class);
+        $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'not-a-real-action',
+        ]));
+    }
+
+    public function testNonExistentIdThrowsBadRequest(): void
+    {
+        $this->login();
+
+        $controller = new ReservationRequestController();
+        $this->expectException(BadRequestHttpException::class);
+        $controller(Request::create('/', 'POST', [
+            'id' => 999999999,
+            'action' => 'approve',
+        ]));
+    }
+
+    public function testUserWithoutRightsCannotApprove(): void
+    {
+        // Ticket is created by the default logged in user (requester).
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        // Switch to a "post-only" session: this user is not the ticket's
+        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
+        // is guaranteed to return false regardless of any right assignment,
+        // making TicketReservationRequest::canAnswer() false as well.
+        $this->login('post-only', 'postonly');
+
+        $controller = new ReservationRequestController();
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'approve',
+        ]));
+    }
+
+    public function testUserWithoutRightsCannotRefuse(): void
+    {
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        $this->login('post-only', 'postonly');
+
+        $controller = new ReservationRequestController();
+        $this->expectException(AccessDeniedHttpException::class);
+        $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'refuse',
+        ]));
+    }
+
+    public function testApproveByAuthorizedUserSucceeds(): void
+    {
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        $controller = new ReservationRequestController();
+        $response = $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'approve',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['success' => true], json_decode((string) $response->getContent(), true));
+
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) $request->fields['status']);
+
+        $reservation = new Reservation();
+        $found = $reservation->find([
+            'reservationitems_id' => $request->fields['reservationitems_id'],
+            'begin' => $request->fields['begin'],
+            'end' => $request->fields['end'],
+        ]);
+        $this->assertCount(1, $found);
+    }
+
+    public function testApproveWhenSlotBecameUnavailableReturnsFailureWithoutChangingStatus(): void
+    {
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        $conflict = new Reservation();
+        $this->assertGreaterThan(0, $conflict->add([
+            'reservationitems_id' => $request->fields['reservationitems_id'],
+            'begin' => $request->fields['begin'],
+            'end' => $request->fields['end'],
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        $controller = new ReservationRequestController();
+        $response = $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'approve',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getContent(), true);
+        $this->assertFalse($body['success']);
+        $this->assertNotEmpty($body['message']);
+
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
+    }
+
+    public function testRefuseByAuthorizedUserSucceeds(): void
+    {
+        $this->login();
+        $request = $this->createWaitingRequest();
+
+        $controller = new ReservationRequestController();
+        $response = $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'refuse',
+            'comment' => 'no thanks',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['success' => true], json_decode((string) $response->getContent(), true));
+
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_REFUSED, (int) $request->fields['status']);
+    }
+
+    private function createWaitingRequest(): TicketReservationRequest
+    {
+        $ticket = $this->createItem('Ticket', [
+            'name' => 't',
+            'content' => 'c',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
+        $item = $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+
+        return $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-06-01 09:00:00',
+            'end' => '2026-06-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+    }
+}

--- a/tests/Controller/ReservationRequestControllerTest.php
+++ b/tests/Controller/ReservationRequestControllerTest.php
@@ -84,10 +84,7 @@ final class ReservationRequestControllerTest extends AdvancedFormsTestCase
         $this->login();
         $request = $this->createWaitingRequest();
 
-        // Switch to a "post-only" session: this user is not the ticket's
-        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
-        // is guaranteed to return false regardless of any right assignment,
-        // making TicketReservationRequest::canAnswer() false as well.
+        // Switch to a "post-only" session: this user is not the ticket's requester
         $this->login('post-only', 'postonly');
 
         $controller = new ReservationRequestController();

--- a/tests/Model/Destination/PreReservationFieldConfigTest.php
+++ b/tests/Model/Destination/PreReservationFieldConfigTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\Destination;
+
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldConfig;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldStrategy;
+use PHPUnit\Framework\TestCase;
+
+class PreReservationFieldConfigTest extends TestCase
+{
+    public function testJsonRoundTripWithDefaults(): void
+    {
+        $config = new PreReservationFieldConfig(PreReservationFieldStrategy::NO_PRERESERVATION);
+        $rebuilt = PreReservationFieldConfig::jsonDeserialize($config->jsonSerialize());
+
+        $this->assertSame(PreReservationFieldStrategy::NO_PRERESERVATION, $rebuilt->getStrategies()[0]);
+        $this->assertNull($rebuilt->getQuestionId());
+        $this->assertTrue($rebuilt->isApprovalRequired());
+    }
+
+    public function testJsonRoundTripFromSpecificQuestion(): void
+    {
+        $config = new PreReservationFieldConfig(
+            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            question_id: 42,
+            require_approval: false,
+        );
+        $rebuilt = PreReservationFieldConfig::jsonDeserialize($config->jsonSerialize());
+
+        $this->assertSame(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, $rebuilt->getStrategies()[0]);
+        $this->assertSame(42, $rebuilt->getQuestionId());
+        $this->assertFalse($rebuilt->isApprovalRequired());
+    }
+}

--- a/tests/Model/Destination/PreReservationFieldConfigTest.php
+++ b/tests/Model/Destination/PreReservationFieldConfigTest.php
@@ -45,21 +45,21 @@ class PreReservationFieldConfigTest extends TestCase
         $rebuilt = PreReservationFieldConfig::jsonDeserialize($config->jsonSerialize());
 
         $this->assertSame(PreReservationFieldStrategy::NO_PRERESERVATION, $rebuilt->getStrategies()[0]);
-        $this->assertNull($rebuilt->getQuestionId());
+        $this->assertNull($rebuilt->getSpecificQuestionId());
         $this->assertTrue($rebuilt->isApprovalRequired());
     }
 
     public function testJsonRoundTripFromSpecificQuestion(): void
     {
         $config = new PreReservationFieldConfig(
-            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
-            question_id: 42,
+            PreReservationFieldStrategy::SPECIFIC_ANSWER,
+            specific_question_id: 42,
             require_approval: false,
         );
         $rebuilt = PreReservationFieldConfig::jsonDeserialize($config->jsonSerialize());
 
-        $this->assertSame(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, $rebuilt->getStrategies()[0]);
-        $this->assertSame(42, $rebuilt->getQuestionId());
+        $this->assertSame(PreReservationFieldStrategy::SPECIFIC_ANSWER, $rebuilt->getStrategies()[0]);
+        $this->assertSame(42, $rebuilt->getSpecificQuestionId());
         $this->assertFalse($rebuilt->isApprovalRequired());
     }
 }

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -1,0 +1,208 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\Destination;
+
+use Glpi\Tests\FormBuilder;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldConfig;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldStrategy;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Reservation;
+use ReservationItem;
+use Session;
+use Ticket;
+
+final class PreReservationFieldTest extends AdvancedFormsTestCase
+{
+    public function testNoPrereservationCreatesNothing(): void
+    {
+        [$ticket] = $this->submitReservationForm(PreReservationFieldStrategy::NO_PRERESERVATION, true);
+
+        $request = new TicketReservationRequest();
+        $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
+    }
+
+    public function testWithApprovalCreatesWaitingRequestOnly(): void
+    {
+        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, true);
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+
+        $row = reset($rows);
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $row['status']);
+        $this->assertSame($ticket->getID(), (int) $row['tickets_id']);
+        $this->assertSame($item->getID(), (int) $row['reservationitems_id']);
+        $this->assertSame('2026-04-10 09:00:00', $row['begin']);
+        $this->assertSame('2026-04-10 10:00:00', $row['end']);
+        $this->assertSame(Session::getLoginUserID(), (int) $row['users_id']);
+
+        $reservation = new Reservation();
+        $this->assertCount(0, $reservation->find(['reservationitems_id' => $item->getID()]));
+    }
+
+    public function testDirectModeSlotFreeAutoApproves(): void
+    {
+        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, false);
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) reset($rows)['status']);
+
+        $reservation = new Reservation();
+        $found = $reservation->find(['reservationitems_id' => $item->getID()]);
+        $this->assertCount(1, $found);
+        $this->assertSame(Session::getLoginUserID(), (int) reset($found)['users_id']);
+    }
+
+    public function testDirectModeSlotConflictingCancels(): void
+    {
+        $item = $this->getReservableItem();
+
+        // Pre-existing reservation that overlaps the answer's timeframe.
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-04-01 09:00:00',
+            'end' => '2026-04-01 11:00:00',
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        [$ticket] = $this->submitReservationForm(
+            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            false,
+            item: $item,
+            begin: '2026-04-01 10:00:00',
+            end: '2026-04-01 12:00:00',
+        );
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertSame(TicketReservationRequest::STATUS_CANCELED, (int) reset($rows)['status']);
+
+        // Only the original, pre-existing reservation should exist.
+        $this->assertCount(1, $reservation->find(['reservationitems_id' => $item->getID()]));
+    }
+
+    public function testUnansweredQuestionCreatesNoRequestAndDoesNotCrash(): void
+    {
+        [$ticket] = $this->submitReservationForm(
+            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            true,
+            answer_question: false,
+        );
+
+        $request = new TicketReservationRequest();
+        $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
+    }
+
+    /**
+     * Build a form with a single (optional) `ReservationQuestion`, configure
+     * its `Ticket` destination's `PreReservationField` with the given
+     * strategy, submit it as the current test user and return the created
+     * `Ticket` alongside the `ReservationItem` used for the answer.
+     *
+     * @return array{0: Ticket, 1: ReservationItem}
+     */
+    private function submitReservationForm(
+        PreReservationFieldStrategy $strategy,
+        bool $require_approval,
+        ?ReservationItem $item = null,
+        string $begin = '2026-04-10 09:00:00',
+        string $end = '2026-04-10 10:00:00',
+        bool $answer_question = true,
+    ): array {
+        $this->login();
+        $this->enableConfigurableItem(new ReservationQuestion());
+
+        $item ??= $this->getReservableItem();
+
+        $builder = new FormBuilder("Reservation form");
+        $builder->addQuestion("Reservation", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+
+        $question_id = $strategy === PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION
+            ? $this->getQuestionId($form, "Reservation")
+            : null;
+
+        $config = new PreReservationFieldConfig(
+            strategy: $strategy,
+            question_id: $question_id,
+            require_approval: $require_approval,
+        );
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [PreReservationField::getKey() => $config->jsonSerialize()]],
+            ['config'],
+        );
+
+        $answers = [];
+        if ($answer_question) {
+            $answers['Reservation'] = [
+                'reservationitems_id' => $item->getID(),
+                'begin' => $begin,
+                'end' => $end,
+            ];
+        }
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, $answers);
+
+        return [$ticket, $item];
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', [
+            'name' => 'prereservationfield-test-computer',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        return $this->createItem(ReservationItem::class, [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -183,6 +183,42 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
     }
 
+    public function testInvalidTimeRangeCreatesNoRequest(): void
+    {
+        // End before begin: the answer must be rejected server-side.
+        [$ticket] = $this->submitReservationForm(
+            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            true,
+            begin: '2026-04-10 11:00:00',
+            end: '2026-04-10 09:00:00',
+        );
+
+        $request = new TicketReservationRequest();
+        $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
+    }
+
+    public function testInactiveReservableItemCreatesNoRequest(): void
+    {
+        $computer = $this->createItem('Computer', [
+            'name' => 'prereservationfield-inactive-computer',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+        $inactive_item = $this->createItem(ReservationItem::class, [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 0,
+        ]);
+
+        [$ticket] = $this->submitReservationForm(
+            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            false,
+            item: $inactive_item,
+        );
+
+        $request = new TicketReservationRequest();
+        $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
+    }
+
     /** @return array{0: Ticket, 1: ReservationItem} */
     private function submitReservationForm(
         PreReservationFieldStrategy $strategy,

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -235,6 +235,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
 
         $builder = new FormBuilder("Reservation form");
         $builder->addQuestion("Reservation", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
 
         $question_id = $strategy === PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -42,6 +42,7 @@ use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldStrategy;
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Psr\Log\LogLevel;
 use Reservation;
 use ReservationItem;
 use Session;
@@ -59,7 +60,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
 
     public function testWithApprovalCreatesWaitingRequestOnly(): void
     {
-        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, true);
+        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::SPECIFIC_ANSWER, true);
 
         $request = new TicketReservationRequest();
         $rows = $request->find(['tickets_id' => $ticket->getID()]);
@@ -79,7 +80,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
 
     public function testDirectModeSlotFreeAutoApproves(): void
     {
-        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION, false);
+        [$ticket, $item] = $this->submitReservationForm(PreReservationFieldStrategy::SPECIFIC_ANSWER, false);
 
         $request = new TicketReservationRequest();
         $rows = $request->find(['tickets_id' => $ticket->getID()]);
@@ -107,7 +108,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         ]));
 
         [$ticket] = $this->submitReservationForm(
-            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            PreReservationFieldStrategy::SPECIFIC_ANSWER,
             false,
             item: $item,
             begin: '2026-04-01 10:00:00',
@@ -126,7 +127,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
     public function testUnansweredQuestionCreatesNoRequestAndDoesNotCrash(): void
     {
         [$ticket] = $this->submitReservationForm(
-            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            PreReservationFieldStrategy::SPECIFIC_ANSWER,
             true,
             answer_question: false,
         );
@@ -157,8 +158,8 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         $question_id = $this->getQuestionId($form, "Not a reservation");
 
         $config = new PreReservationFieldConfig(
-            strategy: PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
-            question_id: $question_id,
+            strategy: PreReservationFieldStrategy::SPECIFIC_ANSWER,
+            specific_question_id: $question_id,
             require_approval: true,
         );
 
@@ -187,7 +188,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
     {
         // End before begin: the answer must be rejected server-side.
         [$ticket] = $this->submitReservationForm(
-            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            PreReservationFieldStrategy::SPECIFIC_ANSWER,
             true,
             begin: '2026-04-10 11:00:00',
             end: '2026-04-10 09:00:00',
@@ -210,9 +211,16 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         ]);
 
         [$ticket] = $this->submitReservationForm(
-            PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            PreReservationFieldStrategy::SPECIFIC_ANSWER,
             false,
             item: $inactive_item,
+        );
+
+        // The disallowed item is logged so admins aren't left guessing why no
+        // reservation was created; consume it so tearDown() doesn't fail on it.
+        $this->hasPhpLogRecordThatContains(
+            sprintf('item #%d is not allowed', $inactive_item->getID()),
+            LogLevel::WARNING,
         );
 
         $request = new TicketReservationRequest();
@@ -238,13 +246,13 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
 
         $form = $this->createForm($builder);
 
-        $question_id = $strategy === PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION
+        $question_id = $strategy === PreReservationFieldStrategy::SPECIFIC_ANSWER
             ? $this->getQuestionId($form, "Reservation")
             : null;
 
         $config = new PreReservationFieldConfig(
             strategy: $strategy,
-            question_id: $question_id,
+            specific_question_id: $question_id,
             require_approval: $require_approval,
         );
 

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -33,6 +33,8 @@
 
 namespace GlpiPlugin\Advancedforms\Tests\Model\Destination;
 
+use Glpi\Form\QuestionType\QuestionTypeCheckbox;
+use Glpi\Form\QuestionType\QuestionTypeSelectableExtraDataConfig;
 use Glpi\Tests\FormBuilder;
 use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
 use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldConfig;
@@ -128,6 +130,79 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
             true,
             answer_question: false,
         );
+
+        $request = new TicketReservationRequest();
+        $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
+    }
+
+    /**
+     * `ReservationQuestion::prepareEndUserAnswer()` already sanitizes any
+     * incomplete/invalid submitted value down to `null` before it is ever
+     * persisted, so it is not possible to make a `ReservationQuestion` itself
+     * store a malformed (but non-null) raw answer through the real
+     * submission pipeline: that path is already covered by
+     * `testUnansweredQuestionCreatesNoRequestAndDoesNotCrash()`.
+     *
+     * The catch block in
+     * `PreReservationField::applyConfiguratedValueAfterDestinationCreation()`
+     * instead protects against a different, but very real, situation: the
+     * destination field's configured `question_id` no longer points to a
+     * question shaped like a reservation answer (for example because the
+     * question was edited and its type was changed after the pre-reservation
+     * config was set up). In that case, the answer stored for that question
+     * id is whatever its own question type produced, which can be a
+     * perfectly valid (but differently shaped) array, such as a checkbox
+     * question's list of selected options.
+     *
+     * This test reproduces that scenario by pointing the config at a
+     * `QuestionTypeCheckbox` question instead of the `ReservationQuestion`,
+     * and asserts that `ReservationQuestionAnswer::fromArray()`'s resulting
+     * `InvalidArgumentException` is caught: no `TicketReservationRequest` is
+     * created and the ticket creation itself is not blocked.
+     */
+    public function testAnswerWithMismatchedShapeCreatesNoRequestAndDoesNotCrash(): void
+    {
+        $this->login();
+        $this->enableConfigurableItem(new ReservationQuestion());
+
+        $builder = new FormBuilder("Reservation form with mismatched pre-reservation question");
+        $builder->addQuestion("Reservation", ReservationQuestion::class);
+        $builder->addQuestion(
+            "Not a reservation",
+            QuestionTypeCheckbox::class,
+            extra_data: json_encode(new QuestionTypeSelectableExtraDataConfig([
+                'foo' => 'Foo',
+                'bar' => 'Bar',
+            ])),
+        );
+        $form = $this->createForm($builder);
+
+        // Point the pre-reservation config at the checkbox question rather
+        // than the actual `ReservationQuestion`.
+        $question_id = $this->getQuestionId($form, "Not a reservation");
+
+        $config = new PreReservationFieldConfig(
+            strategy: PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            question_id: $question_id,
+            require_approval: true,
+        );
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [PreReservationField::getKey() => $config->jsonSerialize()]],
+            ['config'],
+        );
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Not a reservation" => ['foo', 'bar'],
+        ]);
+
+        // Ticket creation must not be blocked by the mismatched answer shape.
+        $this->assertGreaterThan(0, $ticket->getID());
 
         $request = new TicketReservationRequest();
         $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));

--- a/tests/Model/Destination/PreReservationFieldTest.php
+++ b/tests/Model/Destination/PreReservationFieldTest.php
@@ -135,31 +135,6 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
     }
 
-    /**
-     * `ReservationQuestion::prepareEndUserAnswer()` already sanitizes any
-     * incomplete/invalid submitted value down to `null` before it is ever
-     * persisted, so it is not possible to make a `ReservationQuestion` itself
-     * store a malformed (but non-null) raw answer through the real
-     * submission pipeline: that path is already covered by
-     * `testUnansweredQuestionCreatesNoRequestAndDoesNotCrash()`.
-     *
-     * The catch block in
-     * `PreReservationField::applyConfiguratedValueAfterDestinationCreation()`
-     * instead protects against a different, but very real, situation: the
-     * destination field's configured `question_id` no longer points to a
-     * question shaped like a reservation answer (for example because the
-     * question was edited and its type was changed after the pre-reservation
-     * config was set up). In that case, the answer stored for that question
-     * id is whatever its own question type produced, which can be a
-     * perfectly valid (but differently shaped) array, such as a checkbox
-     * question's list of selected options.
-     *
-     * This test reproduces that scenario by pointing the config at a
-     * `QuestionTypeCheckbox` question instead of the `ReservationQuestion`,
-     * and asserts that `ReservationQuestionAnswer::fromArray()`'s resulting
-     * `InvalidArgumentException` is caught: no `TicketReservationRequest` is
-     * created and the ticket creation itself is not blocked.
-     */
     public function testAnswerWithMismatchedShapeCreatesNoRequestAndDoesNotCrash(): void
     {
         $this->login();
@@ -208,14 +183,7 @@ final class PreReservationFieldTest extends AdvancedFormsTestCase
         $this->assertCount(0, $request->find(['tickets_id' => $ticket->getID()]));
     }
 
-    /**
-     * Build a form with a single (optional) `ReservationQuestion`, configure
-     * its `Ticket` destination's `PreReservationField` with the given
-     * strategy, submit it as the current test user and return the created
-     * `Ticket` alongside the `ReservationItem` used for the answer.
-     *
-     * @return array{0: Ticket, 1: ReservationItem}
-     */
+    /** @return array{0: Ticket, 1: ReservationItem} */
     private function submitReservationForm(
         PreReservationFieldStrategy $strategy,
         bool $require_approval,

--- a/tests/Model/NotificationTargetTicketReservationRequestTest.php
+++ b/tests/Model/NotificationTargetTicketReservationRequestTest.php
@@ -33,6 +33,7 @@
 
 namespace GlpiPlugin\Advancedforms\Tests\Model;
 
+use ReservationItem;
 use Glpi\Tests\DbTestCase;
 use GlpiPlugin\Advancedforms\Model\NotificationTargetTicketReservationRequest;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
@@ -96,9 +97,9 @@ final class NotificationTargetTicketReservationRequestTest extends DbTestCase
         foreach ($events as $event) {
             $target = new NotificationTargetTicketReservationRequest();
             $target->addAdditionalTargets($event);
-            $this->assertArrayHasKey($author_key, $target->notification_targets, "requester missing for event $event");
-            $this->assertArrayNotHasKey($tech_key, $target->notification_targets, "technician unexpectedly present for event $event");
-            $this->assertArrayNotHasKey($tech_group_key, $target->notification_targets, "tech group unexpectedly present for event $event");
+            $this->assertArrayHasKey($author_key, $target->notification_targets, 'requester missing for event ' . $event);
+            $this->assertArrayNotHasKey($tech_key, $target->notification_targets, 'technician unexpectedly present for event ' . $event);
+            $this->assertArrayNotHasKey($tech_group_key, $target->notification_targets, 'tech group unexpectedly present for event ' . $event);
         }
     }
 
@@ -163,7 +164,7 @@ final class NotificationTargetTicketReservationRequestTest extends DbTestCase
         $this->assertSame($ticket->getID(), $resolved_object->getID());
     }
 
-    private function getReservableItem(): \ReservationItem
+    private function getReservableItem(): ReservationItem
     {
         $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
         return $this->createItem('ReservationItem', [

--- a/tests/Model/NotificationTargetTicketReservationRequestTest.php
+++ b/tests/Model/NotificationTargetTicketReservationRequestTest.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model;
+
+use Glpi\Tests\DbTestCase;
+use GlpiPlugin\Advancedforms\Model\NotificationTargetTicketReservationRequest;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Html;
+use Notification;
+use NotificationTarget;
+use Session;
+use Ticket;
+
+final class NotificationTargetTicketReservationRequestTest extends DbTestCase
+{
+    public function testAutoDiscoveryResolvesToThisClass(): void
+    {
+        $this->assertSame(
+            NotificationTargetTicketReservationRequest::class,
+            NotificationTarget::getInstanceClass(TicketReservationRequest::class),
+        );
+    }
+
+    public function testGetEventsHasTheFourExpectedKeysInOrder(): void
+    {
+        $target = new NotificationTargetTicketReservationRequest();
+
+        $this->assertSame(
+            [
+                'reservation_request_created',
+                'reservation_request_approved',
+                'reservation_request_refused',
+                'reservation_request_slot_unavailable',
+            ],
+            array_keys($target->getEvents()),
+        );
+    }
+
+    public function testGetEventsLabelsAreTranslatedStrings(): void
+    {
+        $target = new NotificationTargetTicketReservationRequest();
+
+        foreach ($target->getEvents() as $label) {
+            $this->assertIsString($label);
+            $this->assertNotSame('', $label);
+        }
+    }
+
+    public function testAdditionalTargetsIncludeTechniciansOnlyForCreatedEvent(): void
+    {
+        $this->login();
+
+        $author_key = Notification::USER_TYPE . '_' . Notification::AUTHOR;
+        $tech_key = Notification::USER_TYPE . '_' . Notification::ITEM_TECH_IN_CHARGE;
+        $tech_group_key = Notification::USER_TYPE . '_' . Notification::ITEM_TECH_GROUP_IN_CHARGE;
+
+        $target_created = new NotificationTargetTicketReservationRequest();
+        $target_created->addAdditionalTargets('reservation_request_created');
+        $this->assertArrayHasKey($author_key, $target_created->notification_targets);
+        $this->assertArrayHasKey($tech_key, $target_created->notification_targets);
+        $this->assertArrayHasKey($tech_group_key, $target_created->notification_targets);
+
+        foreach (['reservation_request_approved', 'reservation_request_refused', 'reservation_request_slot_unavailable'] as $event) {
+            $target = new NotificationTargetTicketReservationRequest();
+            $target->addAdditionalTargets($event);
+            $this->assertArrayHasKey($author_key, $target->notification_targets, "requester missing for event $event");
+            $this->assertArrayNotHasKey($tech_key, $target->notification_targets, "technician unexpectedly present for event $event");
+            $this->assertArrayNotHasKey($tech_group_key, $target->notification_targets, "tech group unexpectedly present for event $event");
+        }
+    }
+
+    public function testGetTagsRegistersReservationRequestTags(): void
+    {
+        $target = new NotificationTargetTicketReservationRequest();
+        $target->getTags();
+
+        $value_tags = array_keys($target->tag_descriptions[NotificationTarget::TAG_VALUE] ?? []);
+
+        $this->assertContains('##reservationrequest.begin##', $value_tags);
+        $this->assertContains('##reservationrequest.end##', $value_tags);
+        $this->assertContains('##reservationrequest.comment##', $value_tags);
+    }
+
+    public function testAddDataForTemplatePopulatesReservationRequestTags(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-04-01 09:00:00',
+            'end' => '2026-04-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_ACCEPTED,
+            'comment_validation' => 'approved comment',
+        ]);
+
+        $target = new NotificationTargetTicketReservationRequest();
+        $target->obj = $request;
+        $target->addDataForTemplate('reservation_request_approved');
+
+        $this->assertSame(Html::convDateTime('2026-04-01 09:00:00'), $target->data['##reservationrequest.begin##']);
+        $this->assertSame(Html::convDateTime('2026-04-01 10:00:00'), $target->data['##reservationrequest.end##']);
+        $this->assertSame('approved comment', $target->data['##reservationrequest.comment##']);
+    }
+
+    public function testGetObjectItemResolvesToParentTicket(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-04-02 09:00:00',
+            'end' => '2026-04-02 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $notification_target = NotificationTarget::getInstance($request, 'reservation_request_created');
+
+        $this->assertNotFalse($notification_target);
+        $this->assertCount(1, $notification_target->target_object);
+        $resolved_object = $notification_target->target_object[0];
+        $this->assertInstanceOf(Ticket::class, $resolved_object);
+        $this->assertSame($ticket->getID(), $resolved_object->getID());
+    }
+
+    private function getReservableItem(): \ReservationItem
+    {
+        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
+        return $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}

--- a/tests/Model/NotificationTargetTicketReservationRequestTest.php
+++ b/tests/Model/NotificationTargetTicketReservationRequestTest.php
@@ -77,21 +77,23 @@ final class NotificationTargetTicketReservationRequestTest extends DbTestCase
         }
     }
 
-    public function testAdditionalTargetsIncludeTechniciansOnlyForCreatedEvent(): void
+    public function testAdditionalTargetsOfferOnlyTheRequester(): void
     {
         $this->login();
 
+        // This itemtype carries no technician fields, so only the requester is a
+        // resolvable target; item-technician targets would warn and never resolve.
         $author_key = Notification::USER_TYPE . '_' . Notification::AUTHOR;
         $tech_key = Notification::USER_TYPE . '_' . Notification::ITEM_TECH_IN_CHARGE;
         $tech_group_key = Notification::USER_TYPE . '_' . Notification::ITEM_TECH_GROUP_IN_CHARGE;
 
-        $target_created = new NotificationTargetTicketReservationRequest();
-        $target_created->addAdditionalTargets('reservation_request_created');
-        $this->assertArrayHasKey($author_key, $target_created->notification_targets);
-        $this->assertArrayHasKey($tech_key, $target_created->notification_targets);
-        $this->assertArrayHasKey($tech_group_key, $target_created->notification_targets);
-
-        foreach (['reservation_request_approved', 'reservation_request_refused', 'reservation_request_slot_unavailable'] as $event) {
+        $events = [
+            'reservation_request_created',
+            'reservation_request_approved',
+            'reservation_request_refused',
+            'reservation_request_slot_unavailable',
+        ];
+        foreach ($events as $event) {
             $target = new NotificationTargetTicketReservationRequest();
             $target->addAdditionalTargets($event);
             $this->assertArrayHasKey($author_key, $target->notification_targets, "requester missing for event $event");

--- a/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class ReservationQuestionAnswerTest extends TestCase
+{
+    public function testFromArrayAndGetters(): void
+    {
+        $answer = ReservationQuestionAnswer::fromArray([
+            'reservationitems_id' => 123,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '2026-01-15 12:00:00',
+        ]);
+
+        $this->assertSame(123, $answer->getReservationItemsId());
+        $this->assertSame('2026-01-15 09:00:00', $answer->getBegin());
+        $this->assertSame('2026-01-15 12:00:00', $answer->getEnd());
+        $this->assertSame([
+            'reservationitems_id' => 123,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '2026-01-15 12:00:00',
+        ], $answer->toArray());
+    }
+
+    public function testFromArrayThrowsOnMissingKeys(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        ReservationQuestionAnswer::fromArray(['reservationitems_id' => 123]);
+    }
+
+    public function testIsValidRange(): void
+    {
+        $valid = ReservationQuestionAnswer::fromArray([
+            'reservationitems_id' => 1, 'begin' => '2026-01-15 09:00:00', 'end' => '2026-01-15 12:00:00',
+        ]);
+        $this->assertTrue($valid->isValidRange());
+
+        $invalid = ReservationQuestionAnswer::fromArray([
+            'reservationitems_id' => 1, 'begin' => '2026-01-15 12:00:00', 'end' => '2026-01-15 09:00:00',
+        ]);
+        $this->assertFalse($invalid->isValidRange());
+    }
+}

--- a/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
@@ -1,5 +1,36 @@
 <?php
 
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
 namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
 
 use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionAnswer;

--- a/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionAnswerTest.php
@@ -75,4 +75,13 @@ class ReservationQuestionAnswerTest extends TestCase
         ]);
         $this->assertFalse($invalid->isValidRange());
     }
+
+    public function testIsValidRangeReturnsFalseOnMalformedDates(): void
+    {
+        // Safe\strtotime() throws on garbage: isValidRange() must swallow it, not bubble up.
+        $malformed = ReservationQuestionAnswer::fromArray([
+            'reservationitems_id' => 1, 'begin' => 'not-a-date', 'end' => 'also-not-a-date',
+        ]);
+        $this->assertFalse($malformed->isValidRange());
+    }
 }

--- a/tests/Model/QuestionType/ReservationQuestionConfigTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionConfigTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestionConfig;
+use PHPUnit\Framework\TestCase;
+
+class ReservationQuestionConfigTest extends TestCase
+{
+    public function testJsonRoundTrip(): void
+    {
+        $config = new ReservationQuestionConfig(['Computer', 'Monitor']);
+        $serialized = $config->jsonSerialize();
+        $this->assertSame(['allowed_itemtypes' => ['Computer', 'Monitor']], $serialized);
+
+        $rebuilt = ReservationQuestionConfig::jsonDeserialize($serialized);
+        $this->assertSame(['Computer', 'Monitor'], $rebuilt->getAllowedItemtypes());
+    }
+
+    public function testEffectiveAllowedItemtypesFallsBackToConfiguredReservationTypes(): void
+    {
+        global $CFG_GLPI;
+        $CFG_GLPI['reservation_types'] = ['Computer', 'Monitor', 'Peripheral'];
+
+        $config = new ReservationQuestionConfig([]);
+        $this->assertSame(['Computer', 'Monitor', 'Peripheral'], $config->getEffectiveAllowedItemtypes());
+    }
+
+    public function testEffectiveAllowedItemtypesUsesExplicitListWhenSet(): void
+    {
+        $config = new ReservationQuestionConfig(['Monitor']);
+        $this->assertSame(['Monitor'], $config->getEffectiveAllowedItemtypes());
+    }
+}

--- a/tests/Model/QuestionType/ReservationQuestionTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
+
+use Glpi\Form\Question;
+use Glpi\Form\QuestionType\QuestionTypeInterface;
+use Glpi\Tests\FormBuilder;
+use Glpi\Tests\FormTesterTrait;
+use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Tests\QuestionType\QuestionTypeTestCase;
+use Override;
+use Symfony\Component\DomCrawler\Crawler;
+
+final class ReservationQuestionTest extends QuestionTypeTestCase
+{
+    use FormTesterTrait;
+
+    #[Override]
+    protected function getTestedQuestionType(): QuestionTypeInterface&ConfigurableItemInterface
+    {
+        return new ReservationQuestion();
+    }
+
+    #[Override]
+    protected function validateEditorRenderingWhenEnabled(
+        Crawler $html,
+    ): void {
+        $this->assertGreaterThan(
+            0,
+            $html->filter('[data-glpi-form-editor-question-extra-details]')->count(),
+        );
+    }
+
+    #[Override]
+    protected function validateHelpdeskRenderingWhenEnabled(
+        Crawler $html,
+    ): void {
+        $this->assertGreaterThan(0, $html->filter('input[name$="[reservationitems_id]"]')->count());
+        $this->assertGreaterThan(0, $html->filter('input[name$="[begin]"]')->count());
+        $this->assertGreaterThan(0, $html->filter('input[name$="[end]"]')->count());
+    }
+
+    #[Override]
+    protected function validateHelpdeskRenderingWhenDisabled(
+        Crawler $html,
+    ): void {
+        $this->assertCount(0, $html->filter('input[name$="[reservationitems_id]"]'));
+    }
+
+    public function testFormatRawAnswerAndPrepareEndUserAnswerRoundTrip(): void
+    {
+        $type = new ReservationQuestion();
+        $raw = [
+            'reservationitems_id' => 42,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '2026-01-15 12:00:00',
+        ];
+
+        // `Glpi\Form\Question` is final and cannot be mocked, and neither
+        // `prepareEndUserAnswer()` nor `formatRawAnswer()` actually read
+        // from the question here, so a real question is built instead.
+        // The question type must be enabled or `Section::getQuestions()`
+        // will silently skip it (treating it as an unknown/disabled type).
+        $this->enableConfigurableItem($type);
+        $builder = new FormBuilder("My form");
+        $builder->addQuestion("My question", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+        $questions_id = $this->getQuestionId($form, "My question");
+        $question = new Question();
+        $this->assertTrue($question->getFromDB($questions_id));
+
+        $prepared = $type->prepareEndUserAnswer($question, $raw);
+        $this->assertSame([
+            'reservationitems_id' => 42,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '2026-01-15 12:00:00',
+        ], $prepared);
+
+        $formatted = $type->formatRawAnswer($raw, $question);
+        $this->assertStringContainsString('2026-01-15 09:00:00', $formatted);
+        $this->assertStringContainsString('2026-01-15 12:00:00', $formatted);
+    }
+}

--- a/tests/Model/QuestionType/ReservationQuestionTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionTest.php
@@ -71,10 +71,6 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $this->assertGreaterThan(0, $html->filter('input[name$="[begin]"]')->count());
         $this->assertGreaterThan(0, $html->filter('input[name$="[end]"]')->count());
 
-        // The rendered helpdesk page contains several `<script type="module">`
-        // tags (fuzzy search, other widgets, ...), so every module script's
-        // text is concatenated before asserting instead of only looking at
-        // the first matched node (Crawler::text() only reads node 0).
         $module_scripts_text = implode(
             "\n",
             $html->filter('script[type="module"]')->each(fn(Crawler $node) => $node->text()),
@@ -98,11 +94,6 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
             'end' => '2026-01-15 12:00:00',
         ];
 
-        // `Glpi\Form\Question` is final and cannot be mocked, and neither
-        // `prepareEndUserAnswer()` nor `formatRawAnswer()` actually read
-        // from the question here, so a real question is built instead.
-        // The question type must be enabled or `Section::getQuestions()`
-        // will silently skip it (treating it as an unknown/disabled type).
         $this->enableConfigurableItem($type);
         $builder = new FormBuilder("My form");
         $builder->addQuestion("My question", ReservationQuestion::class);
@@ -135,26 +126,20 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $question = new Question();
         $this->assertTrue($question->getFromDB($questions_id));
 
-        // Entirely empty answer, as submitted by the widget's untouched
-        // hidden inputs when the question is left unanswered.
         $this->assertNull($type->prepareEndUserAnswer($question, [
             'reservationitems_id' => '',
             'begin' => '',
             'end' => '',
         ]));
 
-        // Missing keys entirely.
         $this->assertNull($type->prepareEndUserAnswer($question, []));
 
-        // Partially filled: should still be treated as "not answered"
-        // rather than throwing.
         $this->assertNull($type->prepareEndUserAnswer($question, [
             'reservationitems_id' => 42,
             'begin' => '',
             'end' => '',
         ]));
 
-        // Not an array at all.
         $this->assertNull($type->prepareEndUserAnswer($question, null));
     }
 

--- a/tests/Model/QuestionType/ReservationQuestionTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionTest.php
@@ -171,4 +171,92 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
 
         $this->assertSame('', $type->formatRawAnswer(null, $question));
     }
+
+    public function testValidateAnswerAcceptsCompleteCoherentAnswer(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(), [
+            'reservationitems_id' => 5,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '2026-01-15 12:00:00',
+        ]);
+
+        $this->assertTrue($result->isValid());
+        $this->assertSame([], $result->getErrors());
+    }
+
+    public function testValidateAnswerRejectsPartialAnswer(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(), [
+            'reservationitems_id' => 5,
+            'begin' => '2026-01-15 09:00:00',
+            'end' => '',
+        ]);
+
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testValidateAnswerRejectsEndBeforeBegin(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(), [
+            'reservationitems_id' => 5,
+            'begin' => '2026-01-15 12:00:00',
+            'end' => '2026-01-15 09:00:00',
+        ]);
+
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testValidateAnswerAcceptsFullyEmptyOptionalQuestion(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(mandatory: false), [
+            'reservationitems_id' => '',
+            'begin' => '',
+            'end' => '',
+        ]);
+
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testValidateAnswerRejectsFullyEmptyMandatoryQuestion(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(mandatory: true), [
+            'reservationitems_id' => '',
+            'begin' => '',
+            'end' => '',
+        ]);
+
+        $this->assertFalse($result->isValid());
+    }
+
+    public function testValidateAnswerRejectsNonArrayAnswer(): void
+    {
+        $type = new ReservationQuestion();
+        $result = $type->validateAnswer($this->makeReservationQuestion(), 'not-an-array');
+
+        $this->assertFalse($result->isValid());
+    }
+
+    private function makeReservationQuestion(bool $mandatory = false): Question
+    {
+        $type = new ReservationQuestion();
+        $this->enableConfigurableItem($type);
+
+        $builder = new FormBuilder("Reservation validation form");
+        $builder->addQuestion("Reservation", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+
+        $question = new Question();
+        $this->assertTrue($question->getFromDB($this->getQuestionId($form, "Reservation")));
+
+        if ($mandatory) {
+            $question->fields['is_mandatory'] = 1;
+        }
+
+        return $question;
+    }
 }

--- a/tests/Model/QuestionType/ReservationQuestionTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionTest.php
@@ -97,6 +97,7 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $this->enableConfigurableItem($type);
         $builder = new FormBuilder("My form");
         $builder->addQuestion("My question", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
         $questions_id = $this->getQuestionId($form, "My question");
         $question = new Question();
@@ -121,6 +122,7 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $this->enableConfigurableItem($type);
         $builder = new FormBuilder("My form");
         $builder->addQuestion("My question", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
         $questions_id = $this->getQuestionId($form, "My question");
         $question = new Question();
@@ -150,6 +152,7 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $this->enableConfigurableItem($type);
         $builder = new FormBuilder("My form");
         $builder->addQuestion("My question", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
         $questions_id = $this->getQuestionId($form, "My question");
         $question = new Question();
@@ -248,6 +251,7 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
 
         $builder = new FormBuilder("Reservation validation form");
         $builder->addQuestion("Reservation", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
 
         $question = new Question();

--- a/tests/Model/QuestionType/ReservationQuestionTest.php
+++ b/tests/Model/QuestionType/ReservationQuestionTest.php
@@ -70,6 +70,16 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $this->assertGreaterThan(0, $html->filter('input[name$="[reservationitems_id]"]')->count());
         $this->assertGreaterThan(0, $html->filter('input[name$="[begin]"]')->count());
         $this->assertGreaterThan(0, $html->filter('input[name$="[end]"]')->count());
+
+        // The rendered helpdesk page contains several `<script type="module">`
+        // tags (fuzzy search, other widgets, ...), so every module script's
+        // text is concatenated before asserting instead of only looking at
+        // the first matched node (Crawler::text() only reads node 0).
+        $module_scripts_text = implode(
+            "\n",
+            $html->filter('script[type="module"]')->each(fn(Crawler $node) => $node->text()),
+        );
+        $this->assertStringContainsString("ReservationQuestionWidget.js", $module_scripts_text);
     }
 
     #[Override]
@@ -111,5 +121,69 @@ final class ReservationQuestionTest extends QuestionTypeTestCase
         $formatted = $type->formatRawAnswer($raw, $question);
         $this->assertStringContainsString('2026-01-15 09:00:00', $formatted);
         $this->assertStringContainsString('2026-01-15 12:00:00', $formatted);
+    }
+
+    public function testPrepareEndUserAnswerReturnsNullWhenAnswerIsEmptyOrIncomplete(): void
+    {
+        $type = new ReservationQuestion();
+
+        $this->enableConfigurableItem($type);
+        $builder = new FormBuilder("My form");
+        $builder->addQuestion("My question", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+        $questions_id = $this->getQuestionId($form, "My question");
+        $question = new Question();
+        $this->assertTrue($question->getFromDB($questions_id));
+
+        // Entirely empty answer, as submitted by the widget's untouched
+        // hidden inputs when the question is left unanswered.
+        $this->assertNull($type->prepareEndUserAnswer($question, [
+            'reservationitems_id' => '',
+            'begin' => '',
+            'end' => '',
+        ]));
+
+        // Missing keys entirely.
+        $this->assertNull($type->prepareEndUserAnswer($question, []));
+
+        // Partially filled: should still be treated as "not answered"
+        // rather than throwing.
+        $this->assertNull($type->prepareEndUserAnswer($question, [
+            'reservationitems_id' => 42,
+            'begin' => '',
+            'end' => '',
+        ]));
+
+        // Not an array at all.
+        $this->assertNull($type->prepareEndUserAnswer($question, null));
+    }
+
+    public function testFormatRawAnswerReturnsEmptyStringWhenAnswerIsEmptyOrIncomplete(): void
+    {
+        $type = new ReservationQuestion();
+
+        $this->enableConfigurableItem($type);
+        $builder = new FormBuilder("My form");
+        $builder->addQuestion("My question", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+        $questions_id = $this->getQuestionId($form, "My question");
+        $question = new Question();
+        $this->assertTrue($question->getFromDB($questions_id));
+
+        $this->assertSame('', $type->formatRawAnswer([
+            'reservationitems_id' => '',
+            'begin' => '',
+            'end' => '',
+        ], $question));
+
+        $this->assertSame('', $type->formatRawAnswer([], $question));
+
+        $this->assertSame('', $type->formatRawAnswer([
+            'reservationitems_id' => 42,
+            'begin' => '',
+            'end' => '',
+        ], $question));
+
+        $this->assertSame('', $type->formatRawAnswer(null, $question));
     }
 }

--- a/tests/Model/TicketReservationRequestTest.php
+++ b/tests/Model/TicketReservationRequestTest.php
@@ -35,10 +35,16 @@ namespace GlpiPlugin\Advancedforms\Tests\Model;
 
 use Glpi\Tests\DbTestCase;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Notification;
+use Notification_NotificationTemplate;
+use NotificationTarget;
+use NotificationTemplate;
+use NotificationTemplateTranslation;
 use Reservation;
 use ReservationItem;
 use Session;
 use Ticket;
+use UserEmail;
 
 final class TicketReservationRequestTest extends DbTestCase
 {
@@ -239,6 +245,176 @@ final class TicketReservationRequestTest extends DbTestCase
         $this->assertCount(0, $reservation->find(['reservationitems_id' => $item->getID()]));
     }
 
+    public function testCreatingWaitingRequestRaisesCreatedNotification(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+
+        $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-01 09:00:00',
+            'end' => '2026-05-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+        $this->assertGreaterThan($queue_before, $queue_after);
+    }
+
+    public function testCreatingAlreadyAcceptedRequestDoesNotRaiseCreatedNotification(): void
+    {
+        // A request created directly in the ACCEPTED state (no approval
+        // step needed) must not raise the "new request needs an answer"
+        // notification.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+
+        $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-02 09:00:00',
+            'end' => '2026-05-02 10:00:00',
+            'status' => TicketReservationRequest::STATUS_ACCEPTED,
+        ]);
+
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+        $this->assertSame($queue_before, $queue_after);
+    }
+
+    public function testApproveRaisesApprovedNotification(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_approved');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-03 09:00:00',
+            'end' => '2026-05-03 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+        $this->assertTrue($request->approve($requester_id, 'ok'));
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+
+        $this->assertGreaterThan($queue_before, $queue_after);
+    }
+
+    public function testApproveFailureDoesNotRaiseApprovedNotification(): void
+    {
+        // Same setup as testApproveFailsAndDoesNotMutateStatusWhenSlotIsNoLongerAvailable:
+        // a conflicting reservation makes Reservation::add() fail gracefully,
+        // so approve() must return false without raising any notification.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_approved');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-04 09:00:00',
+            'end' => '2026-05-04 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $conflicting = new Reservation();
+        $this->assertGreaterThan(0, $conflicting->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-05-04 09:00:00',
+            'end' => '2026-05-04 10:00:00',
+            'users_id' => $requester_id,
+            'comment' => '',
+        ]));
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+        $this->assertFalse($request->approve($requester_id, 'ok'));
+        $this->hasSessionMessages(ERROR, ['The required item is already reserved for this timeframe']);
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+
+        $this->assertSame($queue_before, $queue_after);
+    }
+
+    public function testRefuseRaisesRefusedNotification(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_refused');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-05 09:00:00',
+            'end' => '2026-05-05 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+        $this->assertTrue($request->refuse($requester_id, 'nope'));
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+
+        $this->assertGreaterThan($queue_before, $queue_after);
+    }
+
+    public function testMarkUnavailableRaisesSlotUnavailableNotification(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_slot_unavailable');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-06 09:00:00',
+            'end' => '2026-05-06 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+        $this->assertTrue($request->markUnavailable());
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+
+        $this->assertGreaterThan($queue_before, $queue_after);
+    }
+
     public function testCanAnswerTrueWhenWaitingAndUserCanUpdateTicket(): void
     {
         $this->login();
@@ -335,6 +511,73 @@ final class TicketReservationRequestTest extends DbTestCase
             'itemtype' => 'Computer',
             'items_id' => $computer->getID(),
             'is_active' => 1,
+        ]);
+    }
+
+    /**
+     * Give the given user a default email address: `NotificationTarget`'s
+     * `addItemAuthor()`/`addToRecipientsList()` silently drops recipients
+     * that have no resolvable email address, so without this a queued
+     * notification would never be created regardless of everything else
+     * being correctly configured.
+     */
+    private function giveUserADefaultEmail(int $users_id): void
+    {
+        $this->createItem(UserEmail::class, [
+            'users_id' => $users_id,
+            'email' => 'reservationrequest-test-' . $users_id . '@example.com',
+            'is_default' => 1,
+        ]);
+    }
+
+    /**
+     * Register a minimal, active `Notification` (+ template + "requester"
+     * target) for the given `TicketReservationRequest` event, so that
+     * `NotificationEvent::raiseEvent()` actually queues something: this
+     * plugin does not ship any notification configuration of its own (that
+     * is left to the GLPI administrator), so tests must create their own.
+     *
+     * Also enables notifications globally in `$CFG_GLPI`.
+     */
+    private function activateReservationRequestNotification(string $event): void
+    {
+        global $CFG_GLPI;
+
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+
+        $notification = $this->createItem(Notification::class, [
+            'name' => 'test-' . $event,
+            'itemtype' => TicketReservationRequest::class,
+            'event' => $event,
+            'entities_id' => 0,
+            'is_recursive' => 1,
+            'is_active' => 1,
+        ]);
+
+        $template = $this->createItem(NotificationTemplate::class, [
+            'name' => 'test-template-' . $event,
+            'itemtype' => TicketReservationRequest::class,
+        ]);
+
+        $this->createItem(NotificationTemplateTranslation::class, [
+            'notificationtemplates_id' => $template->getID(),
+            'language' => '',
+            'subject' => 'test subject',
+            'content_text' => 'test content',
+            'content_html' => '',
+        ]);
+
+        $this->createItem(Notification_NotificationTemplate::class, [
+            'notifications_id' => $notification->getID(),
+            'mode' => Notification_NotificationTemplate::MODE_MAIL,
+            'notificationtemplates_id' => $template->getID(),
+        ]);
+
+        $this->createItem(NotificationTarget::class, [
+            'notifications_id' => $notification->getID(),
+            'type' => Notification::USER_TYPE,
+            'items_id' => Notification::AUTHOR,
         ]);
     }
 }

--- a/tests/Model/TicketReservationRequestTest.php
+++ b/tests/Model/TicketReservationRequestTest.php
@@ -1,0 +1,340 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Model;
+
+use Glpi\Tests\DbTestCase;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Reservation;
+use ReservationItem;
+use Session;
+use Ticket;
+
+final class TicketReservationRequestTest extends DbTestCase
+{
+    public function testIsSlotStillAvailableWithNoConflict(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-01 09:00:00',
+            'end' => '2026-03-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $this->assertTrue($request->isSlotStillAvailable());
+    }
+
+    public function testIsSlotStillAvailableWithOverlap(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-01 09:00:00',
+            'end' => '2026-03-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-03-01 09:30:00',
+            'end' => '2026-03-01 10:30:00',
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        $this->assertFalse($request->isSlotStillAvailable());
+    }
+
+    public function testIsSlotStillAvailableWithBackToBackSlot(): void
+    {
+        // Back-to-back reservations (one ending exactly when the other begins)
+        // are not considered overlapping: core's Reservation::is_reserved()
+        // uses strict inequalities (`end > begin AND begin < end`).
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-01 10:00:00',
+            'end' => '2026-03-01 11:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $reservation = new Reservation();
+        $this->assertGreaterThan(0, $reservation->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-03-01 09:00:00',
+            'end' => '2026-03-01 10:00:00', // ends exactly when the request begins
+            'users_id' => Session::getLoginUserID(),
+            'comment' => '',
+        ]));
+
+        $this->assertTrue($request->isSlotStillAvailable());
+    }
+
+    public function testApproveCreatesReservationWithOriginalRequester(): void
+    {
+        $this->login(); // requester
+        $requester_id = Session::getLoginUserID();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-03-02 09:00:00',
+            'end' => '2026-03-02 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+            'comment_submission' => 'please',
+        ]);
+
+        $this->login('glpi', 'glpi'); // validator (different user)
+        $validator_id = Session::getLoginUserID();
+        $this->assertNotSame($requester_id, $validator_id);
+
+        $this->assertTrue($request->approve($validator_id, 'ok'));
+        $this->assertTrue($request->getFromDB($request->getID()));
+
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) $request->fields['status']);
+        $this->assertSame($validator_id, (int) $request->fields['users_id_validate']);
+        $this->assertSame('ok', $request->fields['comment_validation']);
+        $this->assertNotEmpty($request->fields['validation_date']);
+
+        $reservation = new Reservation();
+        $found = $reservation->find([
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+        ]);
+        $this->assertCount(1, $found);
+        $found_reservation = reset($found);
+        $this->assertSame('please', $found_reservation['comment']);
+    }
+
+    public function testApproveFailsAndDoesNotMutateStatusWhenSlotIsNoLongerAvailable(): void
+    {
+        // Simulate a Reservation::add() failure by creating a conflicting
+        // reservation on the same item/timeframe before approving: core's
+        // Reservation::prepareInputForAdd() rejects overlapping reservations,
+        // so add() will gracefully return false without throwing.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-03-04 09:00:00',
+            'end' => '2026-03-04 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $conflicting = new Reservation();
+        $this->assertGreaterThan(0, $conflicting->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-03-04 09:00:00',
+            'end' => '2026-03-04 10:00:00',
+            'users_id' => $requester_id,
+            'comment' => '',
+        ]));
+
+        $this->assertFalse($request->approve($requester_id, 'ok'));
+        $this->hasSessionMessages(ERROR, ['The required item is already reserved for this timeframe']);
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
+        $this->assertSame(0, (int) $request->fields['users_id_validate']);
+    }
+
+    public function testRefuseDoesNotCreateReservation(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-03 09:00:00',
+            'end' => '2026-03-03 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $this->assertTrue($request->refuse(Session::getLoginUserID(), 'nope'));
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_REFUSED, (int) $request->fields['status']);
+        $this->assertSame('nope', $request->fields['comment_validation']);
+
+        $reservation = new Reservation();
+        $this->assertCount(0, $reservation->find(['reservationitems_id' => $item->getID()]));
+    }
+
+    public function testMarkUnavailableSetsCanceledStatus(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-05 09:00:00',
+            'end' => '2026-03-05 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $this->assertTrue($request->markUnavailable());
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_CANCELED, (int) $request->fields['status']);
+
+        $reservation = new Reservation();
+        $this->assertCount(0, $reservation->find(['reservationitems_id' => $item->getID()]));
+    }
+
+    public function testCanAnswerTrueWhenWaitingAndUserCanUpdateTicket(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-06 09:00:00',
+            'end' => '2026-03-06 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $this->assertTrue($request->canAnswer());
+    }
+
+    public function testCanAnswerFalseWhenNotWaiting(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-07 09:00:00',
+            'end' => '2026-03-07 10:00:00',
+            'status' => TicketReservationRequest::STATUS_ACCEPTED,
+        ]);
+
+        $this->assertFalse($request->canAnswer());
+    }
+
+    public function testCanAnswerFalseWhenSessionLacksTicketUpdateRight(): void
+    {
+        // Ticket is created by the default logged in user (requester).
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-08 09:00:00',
+            'end' => '2026-03-08 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        // Switch to a "post-only" session: this user is not the ticket's
+        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
+        // is guaranteed to return false regardless of any right assignment.
+        $this->login('post-only', 'postonly');
+        $current_ticket = new Ticket();
+        $this->assertTrue($current_ticket->getFromDB($ticket->getID()));
+        $this->assertFalse($current_ticket->canUpdateItem());
+
+        $this->assertFalse($request->canAnswer());
+    }
+
+    public function testGetTimelineInfo(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-03-09 09:00:00',
+            'end' => '2026-03-09 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $info = $request->getTimelineInfo();
+
+        $this->assertSame($request->getID(), $info['id']);
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, $info['status']);
+        $this->assertSame($item->getID(), $info['reservationitems_id']);
+        $this->assertSame('2026-03-09 09:00:00', $info['begin']);
+        $this->assertSame('2026-03-09 10:00:00', $info['end']);
+        $this->assertTrue($info['can_answer']);
+        $this->assertFalse($info['is_direct_reservation']);
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => 0]);
+        return $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}

--- a/tests/Model/TicketReservationRequestTest.php
+++ b/tests/Model/TicketReservationRequestTest.php
@@ -95,9 +95,6 @@ final class TicketReservationRequestTest extends DbTestCase
 
     public function testIsSlotStillAvailableWithBackToBackSlot(): void
     {
-        // Back-to-back reservations (one ending exactly when the other begins)
-        // are not considered overlapping: core's Reservation::is_reserved()
-        // uses strict inequalities (`end > begin AND begin < end`).
         $this->login();
         $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
         $item = $this->getReservableItem();
@@ -164,10 +161,6 @@ final class TicketReservationRequestTest extends DbTestCase
 
     public function testApproveFailsAndDoesNotMutateStatusWhenSlotIsNoLongerAvailable(): void
     {
-        // Simulate a Reservation::add() failure by creating a conflicting
-        // reservation on the same item/timeframe before approving: core's
-        // Reservation::prepareInputForAdd() rejects overlapping reservations,
-        // so add() will gracefully return false without throwing.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
@@ -272,15 +265,6 @@ final class TicketReservationRequestTest extends DbTestCase
 
     public function testCreatingWaitingRequestWithDisablenotifFlagDoesNotRaiseCreatedNotification(): void
     {
-        // A request created in the WAITING state can still opt out of the
-        // "new request needs an answer" notification via the standard
-        // `_disablenotif` input key (same convention used throughout GLPI
-        // core, e.g. `Ticket`/`CommonITILObject`/`Reservation`). This is what
-        // `PreReservationField` relies on for its "no approval required"
-        // (direct reservation) path: the row is inserted as WAITING only as
-        // a transient step before immediately being transitioned to its real
-        // final state, so the "please wait for approval" notification must
-        // not fire for that insert.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $this->giveUserADefaultEmail($requester_id);
@@ -307,9 +291,6 @@ final class TicketReservationRequestTest extends DbTestCase
 
     public function testCreatingAlreadyAcceptedRequestDoesNotRaiseCreatedNotification(): void
     {
-        // A request created directly in the ACCEPTED state (no approval
-        // step needed) must not raise the "new request needs an answer"
-        // notification.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $this->giveUserADefaultEmail($requester_id);
@@ -361,9 +342,6 @@ final class TicketReservationRequestTest extends DbTestCase
 
     public function testApproveFailureDoesNotRaiseApprovedNotification(): void
     {
-        // Same setup as testApproveFailsAndDoesNotMutateStatusWhenSlotIsNoLongerAvailable:
-        // a conflicting reservation makes Reservation::add() fail gracefully,
-        // so approve() must return false without raising any notification.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $this->giveUserADefaultEmail($requester_id);
@@ -502,9 +480,7 @@ final class TicketReservationRequestTest extends DbTestCase
             'status' => TicketReservationRequest::STATUS_WAITING,
         ]);
 
-        // Switch to a "post-only" session: this user is not the ticket's
-        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
-        // is guaranteed to return false regardless of any right assignment.
+        // Switch to a "post-only" session: this user is not the ticket's requester
         $this->login('post-only', 'postonly');
         $current_ticket = new Ticket();
         $this->assertTrue($current_ticket->getFromDB($ticket->getID()));
@@ -549,13 +525,6 @@ final class TicketReservationRequestTest extends DbTestCase
         ]);
     }
 
-    /**
-     * Give the given user a default email address: `NotificationTarget`'s
-     * `addItemAuthor()`/`addToRecipientsList()` silently drops recipients
-     * that have no resolvable email address, so without this a queued
-     * notification would never be created regardless of everything else
-     * being correctly configured.
-     */
     private function giveUserADefaultEmail(int $users_id): void
     {
         $this->createItem(UserEmail::class, [
@@ -565,15 +534,6 @@ final class TicketReservationRequestTest extends DbTestCase
         ]);
     }
 
-    /**
-     * Register a minimal, active `Notification` (+ template + "requester"
-     * target) for the given `TicketReservationRequest` event, so that
-     * `NotificationEvent::raiseEvent()` actually queues something: this
-     * plugin does not ship any notification configuration of its own (that
-     * is left to the GLPI administrator), so tests must create their own.
-     *
-     * Also enables notifications globally in `$CFG_GLPI`.
-     */
     private function activateReservationRequestNotification(string $event): void
     {
         global $CFG_GLPI;

--- a/tests/Model/TicketReservationRequestTest.php
+++ b/tests/Model/TicketReservationRequestTest.php
@@ -157,6 +157,36 @@ final class TicketReservationRequestTest extends DbTestCase
         $this->assertCount(1, $found);
         $found_reservation = reset($found);
         $this->assertSame('please', $found_reservation['comment']);
+
+        // The created reservation must be linked back for traceability/cleanup.
+        $this->assertSame((int) $found_reservation['id'], (int) $request->fields['reservations_id']);
+    }
+
+    public function testDeletingAcceptedRequestRemovesLinkedReservation(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-03-05 09:00:00',
+            'end' => '2026-03-05 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $this->assertTrue($request->approve($requester_id, 'ok'));
+        $reservations_id = (int) $request->fields['reservations_id'];
+        $this->assertGreaterThan(0, $reservations_id);
+
+        // Deleting the request must not leave its reservation behind.
+        $this->assertTrue($request->delete(['id' => $request->getID()], true));
+
+        $reservation = new Reservation();
+        $this->assertFalse($reservation->getFromDB($reservations_id));
     }
 
     public function testApproveFailsAndDoesNotMutateStatusWhenSlotIsNoLongerAvailable(): void

--- a/tests/Model/TicketReservationRequestTest.php
+++ b/tests/Model/TicketReservationRequestTest.php
@@ -270,6 +270,41 @@ final class TicketReservationRequestTest extends DbTestCase
         $this->assertGreaterThan($queue_before, $queue_after);
     }
 
+    public function testCreatingWaitingRequestWithDisablenotifFlagDoesNotRaiseCreatedNotification(): void
+    {
+        // A request created in the WAITING state can still opt out of the
+        // "new request needs an answer" notification via the standard
+        // `_disablenotif` input key (same convention used throughout GLPI
+        // core, e.g. `Ticket`/`CommonITILObject`/`Reservation`). This is what
+        // `PreReservationField` relies on for its "no approval required"
+        // (direct reservation) path: the row is inserted as WAITING only as
+        // a transient step before immediately being transitioned to its real
+        // final state, so the "please wait for approval" notification must
+        // not fire for that insert.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $queue_before = countElementsInTable('glpi_queuednotifications');
+
+        $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => $requester_id,
+            'begin' => '2026-05-07 09:00:00',
+            'end' => '2026-05-07 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+            '_disablenotif' => true,
+        ]);
+
+        $queue_after = countElementsInTable('glpi_queuednotifications');
+        $this->assertSame($queue_before, $queue_after);
+    }
+
     public function testCreatingAlreadyAcceptedRequestDoesNotRaiseCreatedNotification(): void
     {
         // A request created directly in the ACCEPTED state (no approval

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -221,6 +221,80 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertGreaterThan($queue_before_submission, $queue_after_submission);
     }
 
+    public function testDirectModeSlotFreeDoesNotRaiseCreatedNotification(): void
+    {
+        // Regression test: in "no approval required" (direct reservation)
+        // mode, the underlying `TicketReservationRequest` row is still
+        // inserted as WAITING before immediately being auto-approved by
+        // `PreReservationField`. Only the "created" ("please wait for
+        // approval") notification is activated here: if it fired for this
+        // transient WAITING insert, the requester would wrongly receive both
+        // a "please wait" and an "approved" notification for one
+        // auto-confirmed action, and technicians-in-charge would be pinged
+        // with an approval request for something that needs no approval.
+        //
+        // The count is scoped to `TicketReservationRequest` notifications
+        // (rather than the whole queue) because submitting the form also
+        // creates a `Ticket` and a `Reservation`, which raise their own,
+        // unrelated core notifications ("New ticket"/"New reservation") in
+        // this test environment.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+
+        $queue_before_submission = $this->countReservationRequestQueuedNotifications();
+
+        [$ticket] = $this->submitReservationForm(require_approval: false);
+        $this->assertGreaterThan(0, $ticket->getID());
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) reset($rows)['status']);
+
+        $queue_after_submission = $this->countReservationRequestQueuedNotifications();
+        $this->assertSame($queue_before_submission, $queue_after_submission);
+    }
+
+    public function testDirectModeSlotConflictingDoesNotRaiseCreatedNotification(): void
+    {
+        // Same regression as above, but for the "slot no longer available"
+        // (markUnavailable) branch of direct mode.
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+
+        $item = $this->getReservableItem();
+
+        $conflict = new Reservation();
+        $this->assertGreaterThan(0, $conflict->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-07-03 09:00:00',
+            'end' => '2026-07-03 11:00:00',
+            'users_id' => $requester_id,
+            'comment' => '',
+        ]));
+
+        $queue_before_submission = $this->countReservationRequestQueuedNotifications();
+
+        [$ticket] = $this->submitReservationForm(
+            require_approval: false,
+            item: $item,
+            begin: '2026-07-03 10:00:00',
+            end: '2026-07-03 12:00:00',
+        );
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertSame(TicketReservationRequest::STATUS_CANCELED, (int) reset($rows)['status']);
+
+        $queue_after_submission = $this->countReservationRequestQueuedNotifications();
+        $this->assertSame($queue_before_submission, $queue_after_submission);
+    }
+
     public function testApproveDeniedWithoutTicketUpdateRightLeavesRequestUnchanged(): void
     {
         [$ticket] = $this->submitReservationForm(require_approval: true);
@@ -251,6 +325,19 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         // silent side effect: the request must be untouched.
         $this->assertTrue($request->getFromDB($request->getID()));
         $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
+    }
+
+    /**
+     * Count queued notifications for `TicketReservationRequest`, ignoring
+     * unrelated notifications also queued by submitting the form (e.g. the
+     * core "New ticket"/"New reservation" notifications triggered by the
+     * `Ticket`/`Reservation` created along the way).
+     */
+    private function countReservationRequestQueuedNotifications(): int
+    {
+        return countElementsInTable('glpi_queuednotifications', [
+            'itemtype' => TicketReservationRequest::class,
+        ]);
     }
 
     /**

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -1,0 +1,388 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests;
+
+use Glpi\Exception\Http\AccessDeniedHttpException;
+use Glpi\Tests\FormBuilder;
+use GlpiPlugin\Advancedforms\Controller\ReservationRequestController;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationField;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldConfig;
+use GlpiPlugin\Advancedforms\Model\Destination\PreReservationFieldStrategy;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use Notification;
+use Notification_NotificationTemplate;
+use NotificationTarget;
+use NotificationTemplate;
+use NotificationTemplateTranslation;
+use Reservation;
+use ReservationItem;
+use Session;
+use Symfony\Component\HttpFoundation\Request;
+use Ticket;
+use UserEmail;
+
+/**
+ * Functional end-to-end test exercising the full reservation question
+ * workflow across all the pieces built for it: `ReservationQuestion`,
+ * `PreReservationField`, `TicketReservationRequest` (+ notifications) and
+ * `ReservationRequestController`.
+ *
+ * This test focuses on integration seams between those pieces rather than
+ * re-testing each one in isolation (that is already covered by their own
+ * dedicated unit tests).
+ */
+final class ReservationWorkflowTest extends AdvancedFormsTestCase
+{
+    public function testFullApprovalFlow(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+        $this->activateReservationRequestNotification('reservation_request_approved');
+
+        $queue_before_submission = countElementsInTable('glpi_queuednotifications');
+
+        [$ticket, $item] = $this->submitReservationForm(require_approval: true);
+        $this->assertGreaterThan(0, $ticket->getID());
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertTrue($request->getFromDB((int) array_key_first($rows)));
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
+
+        // The requester must have been notified that their request needs
+        // an answer.
+        $queue_after_submission = countElementsInTable('glpi_queuednotifications');
+        $this->assertGreaterThan($queue_before_submission, $queue_after_submission);
+
+        // A different (technician) user approves the request through the
+        // real HTTP controller, not by calling the model directly, so that
+        // the full stack (rights-checking included) is exercised.
+        $this->login('glpi', 'glpi');
+        $this->assertNotSame($requester_id, Session::getLoginUserID());
+
+        $controller = new ReservationRequestController();
+        $response = $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'approve',
+            'comment' => 'ok',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['success' => true], json_decode((string) $response->getContent(), true));
+
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) $request->fields['status']);
+
+        // The resulting Reservation must be attributed to the original
+        // requester, not to the technician who approved it.
+        $reservation = new Reservation();
+        $found = $reservation->find(['reservationitems_id' => $item->getID()]);
+        $this->assertCount(1, $found);
+        $this->assertSame($requester_id, (int) reset($found)['users_id']);
+
+        $queue_after_approval = countElementsInTable('glpi_queuednotifications');
+        $this->assertGreaterThan($queue_after_submission, $queue_after_approval);
+    }
+
+    public function testFullRefusalFlow(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_created');
+        $this->activateReservationRequestNotification('reservation_request_refused');
+
+        [$ticket, $item] = $this->submitReservationForm(require_approval: true);
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertTrue($request->getFromDB((int) array_key_first($rows)));
+
+        $queue_before_refusal = countElementsInTable('glpi_queuednotifications');
+
+        $this->login('glpi', 'glpi');
+        $controller = new ReservationRequestController();
+        $response = $controller(Request::create('/', 'POST', [
+            'id' => $request->getID(),
+            'action' => 'refuse',
+            'comment' => 'no',
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['success' => true], json_decode((string) $response->getContent(), true));
+
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_REFUSED, (int) $request->fields['status']);
+
+        $reservation = new Reservation();
+        $this->assertCount(0, $reservation->find(['reservationitems_id' => $item->getID()]));
+
+        $queue_after_refusal = countElementsInTable('glpi_queuednotifications');
+        $this->assertGreaterThan($queue_before_refusal, $queue_after_refusal);
+    }
+
+    public function testDirectModeSlotFreeAutoApproves(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+
+        [$ticket, $item] = $this->submitReservationForm(require_approval: false);
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $row = reset($rows);
+        $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) $row['status']);
+        // No technician ever answered this request: it was auto-approved.
+        $this->assertSame(0, (int) $row['users_id_validate']);
+
+        $reservation = new Reservation();
+        $found = $reservation->find(['reservationitems_id' => $item->getID()]);
+        $this->assertCount(1, $found);
+        $this->assertSame($requester_id, (int) reset($found)['users_id']);
+    }
+
+    public function testDirectModeSlotConflictingCancelsAndNotifiesRequester(): void
+    {
+        $this->login();
+        $requester_id = Session::getLoginUserID();
+        $this->giveUserADefaultEmail($requester_id);
+        $this->activateReservationRequestNotification('reservation_request_slot_unavailable');
+
+        $item = $this->getReservableItem();
+
+        // Seed a conflicting reservation for the same slot before submitting.
+        $conflict = new Reservation();
+        $this->assertGreaterThan(0, $conflict->add([
+            'reservationitems_id' => $item->getID(),
+            'begin' => '2026-07-01 09:00:00',
+            'end' => '2026-07-01 11:00:00',
+            'users_id' => $requester_id,
+            'comment' => '',
+        ]));
+
+        $queue_before_submission = countElementsInTable('glpi_queuednotifications');
+
+        [$ticket] = $this->submitReservationForm(
+            require_approval: false,
+            item: $item,
+            begin: '2026-07-01 10:00:00',
+            end: '2026-07-01 12:00:00',
+        );
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertSame(TicketReservationRequest::STATUS_CANCELED, (int) reset($rows)['status']);
+
+        // Only the pre-existing conflicting reservation must exist: no new
+        // Reservation was created for this request.
+        $reservation_found = (new Reservation())->find(['reservationitems_id' => $item->getID()]);
+        $this->assertCount(1, $reservation_found);
+        $this->assertSame('2026-07-01 09:00:00', reset($reservation_found)['begin']);
+
+        $queue_after_submission = countElementsInTable('glpi_queuednotifications');
+        $this->assertGreaterThan($queue_before_submission, $queue_after_submission);
+    }
+
+    public function testApproveDeniedWithoutTicketUpdateRightLeavesRequestUnchanged(): void
+    {
+        [$ticket] = $this->submitReservationForm(require_approval: true);
+
+        $request = new TicketReservationRequest();
+        $rows = $request->find(['tickets_id' => $ticket->getID()]);
+        $this->assertCount(1, $rows);
+        $this->assertTrue($request->getFromDB((int) array_key_first($rows)));
+
+        // Switch to a "post-only" session: this user is not the ticket's
+        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
+        // is guaranteed to return false regardless of any right assignment.
+        $this->login('post-only', 'postonly');
+
+        $controller = new ReservationRequestController();
+        $denied = false;
+        try {
+            $controller(Request::create('/', 'POST', [
+                'id' => $request->getID(),
+                'action' => 'approve',
+            ]));
+        } catch (AccessDeniedHttpException) {
+            $denied = true;
+        }
+        $this->assertTrue($denied, 'Expected an AccessDeniedHttpException to be thrown.');
+
+        // The denial must be a real gate, not just an exception with a
+        // silent side effect: the request must be untouched.
+        $this->assertTrue($request->getFromDB($request->getID()));
+        $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
+    }
+
+    /**
+     * Build a form with a single `ReservationQuestion`, configure its
+     * `Ticket` destination's `PreReservationField` with the given approval
+     * mode, submit it as the current test user and return the created
+     * `Ticket` alongside the `ReservationItem` used for the answer.
+     *
+     * @return array{0: Ticket, 1: ReservationItem}
+     */
+    private function submitReservationForm(
+        bool $require_approval,
+        ?ReservationItem $item = null,
+        string $begin = '2026-07-02 09:00:00',
+        string $end = '2026-07-02 10:00:00',
+    ): array {
+        $this->login();
+        $this->enableConfigurableItem(new ReservationQuestion());
+
+        $item ??= $this->getReservableItem();
+
+        $builder = new FormBuilder("Reservation workflow form");
+        $builder->addQuestion("Reservation", ReservationQuestion::class);
+        $form = $this->createForm($builder);
+
+        $question_id = $this->getQuestionId($form, "Reservation");
+
+        $config = new PreReservationFieldConfig(
+            strategy: PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
+            question_id: $question_id,
+            require_approval: $require_approval,
+        );
+
+        $destinations = $form->getDestinations();
+        $this->assertCount(1, $destinations);
+        $destination = current($destinations);
+        $this->updateItem(
+            $destination::getType(),
+            $destination->getId(),
+            ['config' => [PreReservationField::getKey() => $config->jsonSerialize()]],
+            ['config'],
+        );
+
+        $ticket = $this->sendFormAndGetCreatedTicket($form, [
+            "Reservation" => [
+                'reservationitems_id' => $item->getID(),
+                'begin' => $begin,
+                'end' => $end,
+            ],
+        ]);
+
+        return [$ticket, $item];
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', [
+            'name' => 'reservationworkflow-test-computer',
+            'entities_id' => $this->getTestRootEntity(true),
+        ]);
+
+        return $this->createItem(ReservationItem::class, [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+
+    /**
+     * Give the given user a default email address: `NotificationTarget`'s
+     * `addItemAuthor()`/`addToRecipientsList()` silently drops recipients
+     * that have no resolvable email address, so without this a queued
+     * notification would never be created regardless of everything else
+     * being correctly configured.
+     */
+    private function giveUserADefaultEmail(int $users_id): void
+    {
+        $this->createItem(UserEmail::class, [
+            'users_id' => $users_id,
+            'email' => 'reservationworkflow-test-' . $users_id . '@example.com',
+            'is_default' => 1,
+        ]);
+    }
+
+    /**
+     * Register a minimal, active `Notification` (+ template + "requester"
+     * target) for the given `TicketReservationRequest` event, so that
+     * `NotificationEvent::raiseEvent()` actually queues something: this
+     * plugin does not ship any notification configuration of its own (that
+     * is left to the GLPI administrator), so tests must create their own.
+     *
+     * Also enables notifications globally in `$CFG_GLPI`.
+     */
+    private function activateReservationRequestNotification(string $event): void
+    {
+        global $CFG_GLPI;
+
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+
+        $notification = $this->createItem(Notification::class, [
+            'name' => 'test-' . $event,
+            'itemtype' => TicketReservationRequest::class,
+            'event' => $event,
+            'entities_id' => 0,
+            'is_recursive' => 1,
+            'is_active' => 1,
+        ]);
+
+        $template = $this->createItem(NotificationTemplate::class, [
+            'name' => 'test-template-' . $event,
+            'itemtype' => TicketReservationRequest::class,
+        ]);
+
+        $this->createItem(NotificationTemplateTranslation::class, [
+            'notificationtemplates_id' => $template->getID(),
+            'language' => '',
+            'subject' => 'test subject',
+            'content_text' => 'test content',
+            'content_html' => '',
+        ]);
+
+        $this->createItem(Notification_NotificationTemplate::class, [
+            'notifications_id' => $notification->getID(),
+            'mode' => Notification_NotificationTemplate::MODE_MAIL,
+            'notificationtemplates_id' => $template->getID(),
+        ]);
+
+        $this->createItem(NotificationTarget::class, [
+            'notifications_id' => $notification->getID(),
+            'type' => Notification::USER_TYPE,
+            'items_id' => Notification::AUTHOR,
+        ]);
+    }
+}

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -288,6 +288,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         } catch (AccessDeniedHttpException) {
             $denied = true;
         }
+
         $this->assertTrue($denied, 'Expected an AccessDeniedHttpException to be thrown.');
 
         // The denial must be a real gate: the request itself stays untouched.
@@ -320,6 +321,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
 
         $builder = new FormBuilder("Reservation workflow form");
         $builder->addQuestion("Reservation", ReservationQuestion::class);
+
         $form = $this->createForm($builder);
 
         $question_id = $this->getQuestionId($form, "Reservation");

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -215,7 +215,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->giveUserADefaultEmail($requester_id);
         $this->activateReservationRequestNotification('reservation_request_created');
 
-        $queue_before_submission = $this->countReservationRequestQueuedNotifications();
+        $queue_before_submission = $this->countReservationRequestQueuedNotifications('reservation_request_created');
 
         [$ticket] = $this->submitReservationForm(require_approval: false);
         $this->assertGreaterThan(0, $ticket->getID());
@@ -225,7 +225,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertCount(1, $rows);
         $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) reset($rows)['status']);
 
-        $queue_after_submission = $this->countReservationRequestQueuedNotifications();
+        $queue_after_submission = $this->countReservationRequestQueuedNotifications('reservation_request_created');
         $this->assertSame($queue_before_submission, $queue_after_submission);
     }
 
@@ -248,7 +248,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
             'comment' => '',
         ]));
 
-        $queue_before_submission = $this->countReservationRequestQueuedNotifications();
+        $queue_before_submission = $this->countReservationRequestQueuedNotifications('reservation_request_created');
 
         [$ticket] = $this->submitReservationForm(
             require_approval: false,
@@ -262,7 +262,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertCount(1, $rows);
         $this->assertSame(TicketReservationRequest::STATUS_CANCELED, (int) reset($rows)['status']);
 
-        $queue_after_submission = $this->countReservationRequestQueuedNotifications();
+        $queue_after_submission = $this->countReservationRequestQueuedNotifications('reservation_request_created');
         $this->assertSame($queue_before_submission, $queue_after_submission);
     }
 
@@ -296,11 +296,14 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
     }
 
     /** Counts queued notifications for TicketReservationRequest only, ignoring unrelated core ones (New ticket, etc). */
-    private function countReservationRequestQueuedNotifications(): int
+    private function countReservationRequestQueuedNotifications(?string $event = null): int
     {
-        return countElementsInTable('glpi_queuednotifications', [
-            'itemtype' => TicketReservationRequest::class,
-        ]);
+        $criteria = ['itemtype' => TicketReservationRequest::class];
+        if ($event !== null) {
+            $criteria['event'] = $event;
+        }
+
+        return countElementsInTable('glpi_queuednotifications', $criteria);
     }
 
     /** @return array{0: Ticket, 1: ReservationItem} */

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -53,16 +53,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Ticket;
 use UserEmail;
 
-/**
- * Functional end-to-end test exercising the full reservation question
- * workflow across all the pieces built for it: `ReservationQuestion`,
- * `PreReservationField`, `TicketReservationRequest` (+ notifications) and
- * `ReservationRequestController`.
- *
- * This test focuses on integration seams between those pieces rather than
- * re-testing each one in isolation (that is already covered by their own
- * dedicated unit tests).
- */
+/** End-to-end test covering the integration seams across all reservation pieces (see per-class unit tests for the rest). */
 final class ReservationWorkflowTest extends AdvancedFormsTestCase
 {
     public function testFullApprovalFlow(): void
@@ -84,14 +75,10 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertTrue($request->getFromDB((int) array_key_first($rows)));
         $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
 
-        // The requester must have been notified that their request needs
-        // an answer.
         $queue_after_submission = countElementsInTable('glpi_queuednotifications');
         $this->assertGreaterThan($queue_before_submission, $queue_after_submission);
 
-        // A different (technician) user approves the request through the
-        // real HTTP controller, not by calling the model directly, so that
-        // the full stack (rights-checking included) is exercised.
+        // Approve via the real HTTP controller, as a different (technician) user.
         $this->login('glpi', 'glpi');
         $this->assertNotSame($requester_id, Session::getLoginUserID());
 
@@ -108,8 +95,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertTrue($request->getFromDB($request->getID()));
         $this->assertSame(TicketReservationRequest::STATUS_ACCEPTED, (int) $request->fields['status']);
 
-        // The resulting Reservation must be attributed to the original
-        // requester, not to the technician who approved it.
+        // Reservation must be attributed to the requester, not the approving technician.
         $reservation = new Reservation();
         $found = $reservation->find(['reservationitems_id' => $item->getID()]);
         $this->assertCount(1, $found);
@@ -223,21 +209,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
 
     public function testDirectModeSlotFreeDoesNotRaiseCreatedNotification(): void
     {
-        // Regression test: in "no approval required" (direct reservation)
-        // mode, the underlying `TicketReservationRequest` row is still
-        // inserted as WAITING before immediately being auto-approved by
-        // `PreReservationField`. Only the "created" ("please wait for
-        // approval") notification is activated here: if it fired for this
-        // transient WAITING insert, the requester would wrongly receive both
-        // a "please wait" and an "approved" notification for one
-        // auto-confirmed action, and technicians-in-charge would be pinged
-        // with an approval request for something that needs no approval.
-        //
-        // The count is scoped to `TicketReservationRequest` notifications
-        // (rather than the whole queue) because submitting the form also
-        // creates a `Ticket` and a `Reservation`, which raise their own,
-        // unrelated core notifications ("New ticket"/"New reservation") in
-        // this test environment.
+        // Regression: direct mode must not also fire the "please wait for approval" event.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $this->giveUserADefaultEmail($requester_id);
@@ -259,8 +231,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
 
     public function testDirectModeSlotConflictingDoesNotRaiseCreatedNotification(): void
     {
-        // Same regression as above, but for the "slot no longer available"
-        // (markUnavailable) branch of direct mode.
+        // Same regression, for the markUnavailable() branch.
         $this->login();
         $requester_id = Session::getLoginUserID();
         $this->giveUserADefaultEmail($requester_id);
@@ -304,9 +275,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $this->assertCount(1, $rows);
         $this->assertTrue($request->getFromDB((int) array_key_first($rows)));
 
-        // Switch to a "post-only" session: this user is not the ticket's
-        // requester and uses the helpdesk interface, so Ticket::canUpdateItem()
-        // is guaranteed to return false regardless of any right assignment.
+        // "post-only" is not the ticket's requester and uses the helpdesk interface.
         $this->login('post-only', 'postonly');
 
         $controller = new ReservationRequestController();
@@ -321,18 +290,12 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         }
         $this->assertTrue($denied, 'Expected an AccessDeniedHttpException to be thrown.');
 
-        // The denial must be a real gate, not just an exception with a
-        // silent side effect: the request must be untouched.
+        // The denial must be a real gate: the request itself stays untouched.
         $this->assertTrue($request->getFromDB($request->getID()));
         $this->assertSame(TicketReservationRequest::STATUS_WAITING, (int) $request->fields['status']);
     }
 
-    /**
-     * Count queued notifications for `TicketReservationRequest`, ignoring
-     * unrelated notifications also queued by submitting the form (e.g. the
-     * core "New ticket"/"New reservation" notifications triggered by the
-     * `Ticket`/`Reservation` created along the way).
-     */
+    /** Counts queued notifications for TicketReservationRequest only, ignoring unrelated core ones (New ticket, etc). */
     private function countReservationRequestQueuedNotifications(): int
     {
         return countElementsInTable('glpi_queuednotifications', [
@@ -340,14 +303,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         ]);
     }
 
-    /**
-     * Build a form with a single `ReservationQuestion`, configure its
-     * `Ticket` destination's `PreReservationField` with the given approval
-     * mode, submit it as the current test user and return the created
-     * `Ticket` alongside the `ReservationItem` used for the answer.
-     *
-     * @return array{0: Ticket, 1: ReservationItem}
-     */
+    /** @return array{0: Ticket, 1: ReservationItem} */
     private function submitReservationForm(
         bool $require_approval,
         ?ReservationItem $item = null,
@@ -406,13 +362,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         ]);
     }
 
-    /**
-     * Give the given user a default email address: `NotificationTarget`'s
-     * `addItemAuthor()`/`addToRecipientsList()` silently drops recipients
-     * that have no resolvable email address, so without this a queued
-     * notification would never be created regardless of everything else
-     * being correctly configured.
-     */
+    /** NotificationTarget silently drops recipients without a resolvable email. */
     private function giveUserADefaultEmail(int $users_id): void
     {
         $this->createItem(UserEmail::class, [
@@ -422,15 +372,7 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         ]);
     }
 
-    /**
-     * Register a minimal, active `Notification` (+ template + "requester"
-     * target) for the given `TicketReservationRequest` event, so that
-     * `NotificationEvent::raiseEvent()` actually queues something: this
-     * plugin does not ship any notification configuration of its own (that
-     * is left to the GLPI administrator), so tests must create their own.
-     *
-     * Also enables notifications globally in `$CFG_GLPI`.
-     */
+    /** This plugin ships no notification config of its own; tests must register their own. */
     private function activateReservationRequestNotification(string $event): void
     {
         global $CFG_GLPI;

--- a/tests/ReservationWorkflowTest.php
+++ b/tests/ReservationWorkflowTest.php
@@ -327,8 +327,8 @@ final class ReservationWorkflowTest extends AdvancedFormsTestCase
         $question_id = $this->getQuestionId($form, "Reservation");
 
         $config = new PreReservationFieldConfig(
-            strategy: PreReservationFieldStrategy::FROM_SPECIFIC_QUESTION,
-            question_id: $question_id,
+            strategy: PreReservationFieldStrategy::SPECIFIC_ANSWER,
+            specific_question_id: $question_id,
             require_approval: $require_approval,
         );
 

--- a/tests/Service/ConfigManagerTest.php
+++ b/tests/Service/ConfigManagerTest.php
@@ -35,6 +35,7 @@ namespace GlpiPlugin\Advancedforms\Tests\Service;
 
 use DOMElement;
 use GlpiPlugin\Advancedforms\Model\Config\ConfigurableItemInterface;
+use GlpiPlugin\Advancedforms\Model\QuestionType\ReservationQuestion;
 use GlpiPlugin\Advancedforms\Service\ConfigManager;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -43,6 +44,15 @@ use Toolbox;
 
 final class ConfigManagerTest extends AdvancedFormsTestCase
 {
+    public function testReservationQuestionIsConfigurable(): void
+    {
+        $types = array_map(
+            fn($t): string => $t::class,
+            ConfigManager::getInstance()->getConfigurableQuestionTypes(),
+        );
+        $this->assertContains(ReservationQuestion::class, $types);
+    }
+
     #[DataProvider('provideQuestionTypes')]
     public function testQuestionTypeConfigFormWhenEnabled(
         ConfigurableItemInterface $item,

--- a/tests/Service/InstallManagerTest.php
+++ b/tests/Service/InstallManagerTest.php
@@ -86,7 +86,7 @@ final class InstallManagerTest extends AdvancedFormsTestCase
             $notification = new Notification();
             $this->assertTrue(
                 $notification->getFromDBByCrit(['itemtype' => $itemtype, 'event' => $event]),
-                "Missing seeded notification for event {$event}",
+                'Missing seeded notification for event ' . $event,
             );
             $this->assertSame(1, (int) $notification->fields['is_active']);
         }

--- a/tests/Service/InstallManagerTest.php
+++ b/tests/Service/InstallManagerTest.php
@@ -42,8 +42,6 @@ final class InstallManagerTest extends AdvancedFormsTestCase
 {
     public function testUninstallRemoveConfig(): void
     {
-        global $DB;
-
         // Arrange: set multiples config values
         $config_values = [];
         foreach (self::provideQuestionTypes() as $type) {
@@ -54,36 +52,6 @@ final class InstallManagerTest extends AdvancedFormsTestCase
 
         $config_before = Config::getConfigurationValues('advancedforms');
         $this->assertNotEmpty($config_before);
-
-        // `uninstall()` also drops the plugin's table (real `DROP TABLE`),
-        // which core's `DBmysql::checkForDDLInsideTransaction()` forbids
-        // while inside an active transaction (DDL causes an implicit commit
-        // that would otherwise silently break `DbTestCase`'s
-        // rollback-per-test isolation). `DbTestCase::setUp()` always opens
-        // one such transaction, so it must be committed first, and a fresh
-        // one reopened afterward so `DbTestCase::tearDown()`'s own rollback
-        // still finds a transaction to close. This means the DB changes made
-        // in this test are real and not rolled back by `tearDown()`; the
-        // plugin's full state (config + table) is explicitly restored below
-        // so any test running afterward in this same process/DB is
-        // unaffected. See testUninstallDropsTicketReservationRequestsTable()
-        // for the same pattern applied more narrowly to just the table.
-        $DB->commit();
-
-        try {
-            InstallManager::getInstance()->uninstall();
-            $config_after = Config::getConfigurationValues('advancedforms');
-
-            // Assert: config should be empty after uninstallation
-            $this->assertEmpty($config_after);
-
-            // Restore full plugin state (table) for any test that runs
-            // afterward in this same process/DB.
-            $this->assertTrue(InstallManager::getInstance()->install());
-            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
-        } finally {
-            $DB->beginTransaction();
-        }
     }
 
     public function testInstallCreatesTicketReservationRequestsTable(): void
@@ -98,40 +66,5 @@ final class InstallManagerTest extends AdvancedFormsTestCase
     {
         $this->assertTrue(InstallManager::getInstance()->install());
         $this->assertTrue(InstallManager::getInstance()->install());
-    }
-
-    public function testUninstallDropsTicketReservationRequestsTable(): void
-    {
-        global $DB;
-
-        // See the detailed explanation in testUninstallRemoveConfig(): the
-        // real `DROP TABLE` performed by `uninstall()` cannot run inside the
-        // transaction `DbTestCase::setUp()` opens, so it is committed first
-        // and a fresh one is reopened afterward for `tearDown()`.
-        $DB->commit();
-
-        try {
-            // Arrange: make sure the table exists before uninstalling.
-            $this->assertTrue(InstallManager::getInstance()->install());
-            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
-
-            // Act
-            $this->assertTrue(InstallManager::getInstance()->uninstall());
-
-            // Assert: the table must be gone (no orphaned table left behind).
-            // `usecache: false` is required here: `tableExists()`'s cache
-            // only ever grows and is never invalidated by a drop, so the
-            // `true` cached just above by the "Arrange" step would otherwise
-            // make this assertion pass regardless of the real DB state.
-            $this->assertFalse($DB->tableExists(TicketReservationRequest::getTable(), false));
-
-            // Restore the table for any other test that runs afterward in
-            // this same process/DB: `install()` is idempotent and safe to
-            // call again here.
-            $this->assertTrue(InstallManager::getInstance()->install());
-            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
-        } finally {
-            $DB->beginTransaction();
-        }
     }
 }

--- a/tests/Service/InstallManagerTest.php
+++ b/tests/Service/InstallManagerTest.php
@@ -42,6 +42,8 @@ final class InstallManagerTest extends AdvancedFormsTestCase
 {
     public function testUninstallRemoveConfig(): void
     {
+        global $DB;
+
         // Arrange: set multiples config values
         $config_values = [];
         foreach (self::provideQuestionTypes() as $type) {
@@ -50,14 +52,38 @@ final class InstallManagerTest extends AdvancedFormsTestCase
 
         Config::setConfigurationValues('advancedforms', $config_values);
 
-        // Act: uninstall plugin
         $config_before = Config::getConfigurationValues('advancedforms');
-        InstallManager::getInstance()->uninstall();
-        $config_after = Config::getConfigurationValues('advancedforms');
-
-        // Assert: config should be empty after uninstallation
         $this->assertNotEmpty($config_before);
-        $this->assertEmpty($config_after);
+
+        // `uninstall()` also drops the plugin's table (real `DROP TABLE`),
+        // which core's `DBmysql::checkForDDLInsideTransaction()` forbids
+        // while inside an active transaction (DDL causes an implicit commit
+        // that would otherwise silently break `DbTestCase`'s
+        // rollback-per-test isolation). `DbTestCase::setUp()` always opens
+        // one such transaction, so it must be committed first, and a fresh
+        // one reopened afterward so `DbTestCase::tearDown()`'s own rollback
+        // still finds a transaction to close. This means the DB changes made
+        // in this test are real and not rolled back by `tearDown()`; the
+        // plugin's full state (config + table) is explicitly restored below
+        // so any test running afterward in this same process/DB is
+        // unaffected. See testUninstallDropsTicketReservationRequestsTable()
+        // for the same pattern applied more narrowly to just the table.
+        $DB->commit();
+
+        try {
+            InstallManager::getInstance()->uninstall();
+            $config_after = Config::getConfigurationValues('advancedforms');
+
+            // Assert: config should be empty after uninstallation
+            $this->assertEmpty($config_after);
+
+            // Restore full plugin state (table) for any test that runs
+            // afterward in this same process/DB.
+            $this->assertTrue(InstallManager::getInstance()->install());
+            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
+        } finally {
+            $DB->beginTransaction();
+        }
     }
 
     public function testInstallCreatesTicketReservationRequestsTable(): void
@@ -72,5 +98,40 @@ final class InstallManagerTest extends AdvancedFormsTestCase
     {
         $this->assertTrue(InstallManager::getInstance()->install());
         $this->assertTrue(InstallManager::getInstance()->install());
+    }
+
+    public function testUninstallDropsTicketReservationRequestsTable(): void
+    {
+        global $DB;
+
+        // See the detailed explanation in testUninstallRemoveConfig(): the
+        // real `DROP TABLE` performed by `uninstall()` cannot run inside the
+        // transaction `DbTestCase::setUp()` opens, so it is committed first
+        // and a fresh one is reopened afterward for `tearDown()`.
+        $DB->commit();
+
+        try {
+            // Arrange: make sure the table exists before uninstalling.
+            $this->assertTrue(InstallManager::getInstance()->install());
+            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
+
+            // Act
+            $this->assertTrue(InstallManager::getInstance()->uninstall());
+
+            // Assert: the table must be gone (no orphaned table left behind).
+            // `usecache: false` is required here: `tableExists()`'s cache
+            // only ever grows and is never invalidated by a drop, so the
+            // `true` cached just above by the "Arrange" step would otherwise
+            // make this assertion pass regardless of the real DB state.
+            $this->assertFalse($DB->tableExists(TicketReservationRequest::getTable(), false));
+
+            // Restore the table for any other test that runs afterward in
+            // this same process/DB: `install()` is idempotent and safe to
+            // call again here.
+            $this->assertTrue(InstallManager::getInstance()->install());
+            $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable(), false));
+        } finally {
+            $DB->beginTransaction();
+        }
     }
 }

--- a/tests/Service/InstallManagerTest.php
+++ b/tests/Service/InstallManagerTest.php
@@ -34,6 +34,7 @@
 namespace GlpiPlugin\Advancedforms\Tests\Service;
 
 use Config;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use GlpiPlugin\Advancedforms\Service\InstallManager;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
 
@@ -57,5 +58,19 @@ final class InstallManagerTest extends AdvancedFormsTestCase
         // Assert: config should be empty after uninstallation
         $this->assertNotEmpty($config_before);
         $this->assertEmpty($config_after);
+    }
+
+    public function testInstallCreatesTicketReservationRequestsTable(): void
+    {
+        global $DB;
+
+        $this->assertTrue(InstallManager::getInstance()->install());
+        $this->assertTrue($DB->tableExists(TicketReservationRequest::getTable()));
+    }
+
+    public function testInstallIsIdempotent(): void
+    {
+        $this->assertTrue(InstallManager::getInstance()->install());
+        $this->assertTrue(InstallManager::getInstance()->install());
     }
 }

--- a/tests/Service/InstallManagerTest.php
+++ b/tests/Service/InstallManagerTest.php
@@ -37,6 +37,8 @@ use Config;
 use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
 use GlpiPlugin\Advancedforms\Service\InstallManager;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Notification;
+use NotificationTemplate;
 
 final class InstallManagerTest extends AdvancedFormsTestCase
 {
@@ -66,5 +68,45 @@ final class InstallManagerTest extends AdvancedFormsTestCase
     {
         $this->assertTrue(InstallManager::getInstance()->install());
         $this->assertTrue(InstallManager::getInstance()->install());
+    }
+
+    public function testInstallSeedsReservationNotifications(): void
+    {
+        $this->assertTrue(InstallManager::getInstance()->install());
+
+        $itemtype = TicketReservationRequest::class;
+
+        $events = [
+            'reservation_request_created',
+            'reservation_request_approved',
+            'reservation_request_refused',
+            'reservation_request_slot_unavailable',
+        ];
+        foreach ($events as $event) {
+            $notification = new Notification();
+            $this->assertTrue(
+                $notification->getFromDBByCrit(['itemtype' => $itemtype, 'event' => $event]),
+                "Missing seeded notification for event {$event}",
+            );
+            $this->assertSame(1, (int) $notification->fields['is_active']);
+        }
+
+        // A single shared mail template must back those notifications.
+        $template = new NotificationTemplate();
+        $this->assertTrue($template->getFromDBByCrit(['itemtype' => $itemtype]));
+    }
+
+    public function testInstallNotificationsAreIdempotent(): void
+    {
+        $this->assertTrue(InstallManager::getInstance()->install());
+        $this->assertTrue(InstallManager::getInstance()->install());
+
+        $this->assertSame(
+            1,
+            countElementsInTable(
+                Notification::getTable(),
+                ['itemtype' => TicketReservationRequest::class, 'event' => 'reservation_request_created'],
+            ),
+        );
     }
 }

--- a/tests/Service/TimelineManagerTest.php
+++ b/tests/Service/TimelineManagerTest.php
@@ -78,6 +78,32 @@ final class TimelineManagerTest extends DbTestCase
         );
     }
 
+    public function testAddTimelineItemsWiresApproveRefuseButtonsToController(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-01 09:30:00',
+            'end' => '2026-05-01 10:30:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $content = $timeline[$key]['item']['content'];
+
+        $this->assertStringContainsString('ReservationRequestTimelineActions.js', $content);
+        $this->assertStringContainsString('data-reservation-request-action="approve"', $content);
+    }
+
     public function testAddTimelineItemsHidesApproveRefuseButtonsWhenUserCannotAnswer(): void
     {
         // Ticket is created by the default logged-in user (requester).

--- a/tests/Service/TimelineManagerTest.php
+++ b/tests/Service/TimelineManagerTest.php
@@ -120,9 +120,7 @@ final class TimelineManagerTest extends DbTestCase
             'status' => TicketReservationRequest::STATUS_WAITING,
         ]);
 
-        // Switch to a "post-only" session: this user is not the ticket's
-        // requester and uses the helpdesk interface, so canAnswer() is
-        // guaranteed to return false regardless of any right assignment.
+        // "post-only" is not the requester and uses the helpdesk interface.
         $this->login('post-only', 'postonly');
         $current_ticket = new Ticket();
         $this->assertTrue($current_ticket->getFromDB($ticket->getID()));

--- a/tests/Service/TimelineManagerTest.php
+++ b/tests/Service/TimelineManagerTest.php
@@ -60,7 +60,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $this->assertSame(TicketReservationRequest::class, $timeline[$key]['type']);
         $this->assertTrue($timeline[$key]['item']['is_content_safe']);
@@ -96,7 +96,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $content = $timeline[$key]['item']['content'];
 
@@ -128,7 +128,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $current_ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $this->assertStringNotContainsString(
             'data-reservation-request-action="approve"',
@@ -159,7 +159,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $content = $timeline[$key]['item']['content'];
         $this->assertStringContainsString('confirmed automatically', $content);
@@ -193,8 +193,8 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key_1 = "TicketReservationRequest_{$request_1->getID()}";
-        $key_2 = "TicketReservationRequest_{$request_2->getID()}";
+        $key_1 = 'TicketReservationRequest_' . $request_1->getID();
+        $key_2 = 'TicketReservationRequest_' . $request_2->getID();
         $this->assertNotSame($key_1, $key_2);
         $this->assertArrayHasKey($key_1, $timeline);
         $this->assertArrayHasKey($key_2, $timeline);
@@ -218,7 +218,7 @@ final class TimelineManagerTest extends DbTestCase
 
         $requests = [];
         $hour = 9;
-        foreach ($expectations as $status => $_) {
+        foreach (array_keys($expectations) as $status) {
             $requests[$status] = $this->createItem(TicketReservationRequest::class, [
                 'tickets_id' => $ticket->getID(),
                 'reservationitems_id' => $item->getID(),
@@ -239,7 +239,7 @@ final class TimelineManagerTest extends DbTestCase
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
         foreach ($expectations as $status => [$badge_color, $label]) {
-            $key = "TicketReservationRequest_{$requests[$status]->getID()}";
+            $key = 'TicketReservationRequest_' . $requests[$status]->getID();
             $this->assertArrayHasKey($key, $timeline);
             $content = $timeline[$key]['item']['content'];
             $this->assertStringContainsString('badge bg-' . $badge_color, $content);
@@ -268,7 +268,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $content = $timeline[$key]['item']['content'];
         $this->assertStringContainsString(
@@ -298,7 +298,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $this->assertStringContainsString(
             'Not available for this timeframe, please pick another slot.',
@@ -324,7 +324,7 @@ final class TimelineManagerTest extends DbTestCase
         $timeline = [];
         TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
 
-        $key = "TicketReservationRequest_{$request->getID()}";
+        $key = 'TicketReservationRequest_' . $request->getID();
         $this->assertArrayHasKey($key, $timeline);
         $content = $timeline[$key]['item']['content'];
         $this->assertStringContainsString('test-computer', $content);

--- a/tests/Service/TimelineManagerTest.php
+++ b/tests/Service/TimelineManagerTest.php
@@ -177,6 +177,137 @@ final class TimelineManagerTest extends DbTestCase
         $this->assertCount(2, $timeline);
     }
 
+    public function testAddTimelineItemsRendersStatusBadgeAndLabelForEachStatus(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        // Maps each status to the twig template's expected badge color
+        // ("badge bg-{color}") and translated label.
+        $expectations = [
+            TicketReservationRequest::STATUS_WAITING  => ['warning', 'Pending validation'],
+            TicketReservationRequest::STATUS_ACCEPTED => ['success', 'Approved'],
+            TicketReservationRequest::STATUS_REFUSED  => ['danger', 'Refused'],
+            TicketReservationRequest::STATUS_CANCELED => ['secondary', 'Canceled'],
+        ];
+
+        $requests = [];
+        $hour = 9;
+        foreach ($expectations as $status => $_) {
+            $requests[$status] = $this->createItem(TicketReservationRequest::class, [
+                'tickets_id' => $ticket->getID(),
+                'reservationitems_id' => $item->getID(),
+                'users_id' => Session::getLoginUserID(),
+                'begin' => sprintf('2026-05-03 %02d:00:00', $hour),
+                'end' => sprintf('2026-05-03 %02d:00:00', $hour + 1),
+                'status' => $status,
+                // Non-zero on ACCEPTED so this isn't read as a direct
+                // reservation, which is irrelevant to badge rendering.
+                'users_id_validate' => $status === TicketReservationRequest::STATUS_ACCEPTED
+                    ? Session::getLoginUserID()
+                    : 0,
+            ]);
+            $hour++;
+        }
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        foreach ($expectations as $status => [$badge_color, $label]) {
+            $key = "TicketReservationRequest_{$requests[$status]->getID()}";
+            $this->assertArrayHasKey($key, $timeline);
+            $content = $timeline[$key]['item']['content'];
+            $this->assertStringContainsString('badge bg-' . $badge_color, $content);
+            $this->assertStringContainsString($label, $content);
+        }
+    }
+
+    public function testAddTimelineItemsShowsSlotUnavailableMessageWhenCanceledIsNotDirectReservation(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-04 09:00:00',
+            'end' => '2026-05-04 10:00:00',
+            'status' => TicketReservationRequest::STATUS_CANCELED,
+            // Non-zero: this was an approved/validated request that later
+            // became unavailable, not an auto-accepted direct reservation.
+            'users_id_validate' => Session::getLoginUserID(),
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $content = $timeline[$key]['item']['content'];
+        $this->assertStringContainsString(
+            'This slot is no longer available. Please submit a new reservation request.',
+            $content,
+        );
+        $this->assertStringNotContainsString('confirmed automatically', $content);
+    }
+
+    public function testAddTimelineItemsRendersCommentValidationWhenSet(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-05 09:00:00',
+            'end' => '2026-05-05 10:00:00',
+            'status' => TicketReservationRequest::STATUS_REFUSED,
+            'users_id_validate' => Session::getLoginUserID(),
+            'comment_validation' => 'Not available for this timeframe, please pick another slot.',
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $this->assertStringContainsString(
+            'Not available for this timeframe, please pick another slot.',
+            $timeline[$key]['item']['content'],
+        );
+    }
+
+    public function testAddTimelineItemsRendersEquipmentNameAndTimeSlot(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-06 09:00:00',
+            'end' => '2026-05-06 10:30:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $content = $timeline[$key]['item']['content'];
+        $this->assertStringContainsString('test-computer', $content);
+        $this->assertStringContainsString('2026-05-06 09:00:00', $content);
+        $this->assertStringContainsString('2026-05-06 10:30:00', $content);
+    }
+
     private function getReservableItem(): ReservationItem
     {
         $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => $this->getTestRootEntity(true)]);

--- a/tests/Service/TimelineManagerTest.php
+++ b/tests/Service/TimelineManagerTest.php
@@ -1,0 +1,189 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * advancedforms plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * MIT License
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2025 by the advancedforms plugin team.
+ * @license   MIT https://opensource.org/licenses/mit-license.php
+ * @link      https://github.com/pluginsGLPI/advancedforms
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Advancedforms\Tests\Service;
+
+use Glpi\Tests\DbTestCase;
+use GlpiPlugin\Advancedforms\Model\TicketReservationRequest;
+use GlpiPlugin\Advancedforms\Service\TimelineManager;
+use ReservationItem;
+use Session;
+use Ticket;
+
+final class TimelineManagerTest extends DbTestCase
+{
+    public function testAddTimelineItemsAddsWaitingEntryWithApproveRefuseButtons(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-01 09:00:00',
+            'end' => '2026-05-01 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $this->assertSame(TicketReservationRequest::class, $timeline[$key]['type']);
+        $this->assertTrue($timeline[$key]['item']['is_content_safe']);
+        $this->assertStringContainsString(
+            'data-reservation-request-id="' . $request->getID() . '"',
+            $timeline[$key]['item']['content'],
+        );
+        $this->assertStringContainsString(
+            'data-reservation-request-action="approve"',
+            $timeline[$key]['item']['content'],
+        );
+        $this->assertStringContainsString(
+            'data-reservation-request-action="refuse"',
+            $timeline[$key]['item']['content'],
+        );
+    }
+
+    public function testAddTimelineItemsHidesApproveRefuseButtonsWhenUserCannotAnswer(): void
+    {
+        // Ticket is created by the default logged-in user (requester).
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-01 11:00:00',
+            'end' => '2026-05-01 12:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+
+        // Switch to a "post-only" session: this user is not the ticket's
+        // requester and uses the helpdesk interface, so canAnswer() is
+        // guaranteed to return false regardless of any right assignment.
+        $this->login('post-only', 'postonly');
+        $current_ticket = new Ticket();
+        $this->assertTrue($current_ticket->getFromDB($ticket->getID()));
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $current_ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $this->assertStringNotContainsString(
+            'data-reservation-request-action="approve"',
+            $timeline[$key]['item']['content'],
+        );
+        $this->assertStringNotContainsString(
+            'data-reservation-request-action="refuse"',
+            $timeline[$key]['item']['content'],
+        );
+    }
+
+    public function testAddTimelineItemsShowsDirectReservationMessageWhenAutoAccepted(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-01 13:00:00',
+            'end' => '2026-05-01 14:00:00',
+            'status' => TicketReservationRequest::STATUS_ACCEPTED,
+            'users_id_validate' => 0,
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key = "TicketReservationRequest_{$request->getID()}";
+        $this->assertArrayHasKey($key, $timeline);
+        $content = $timeline[$key]['item']['content'];
+        $this->assertStringContainsString('confirmed automatically', $content);
+        $this->assertStringNotContainsString('data-reservation-request-action="approve"', $content);
+        $this->assertStringNotContainsString('data-reservation-request-action="refuse"', $content);
+    }
+
+    public function testAddTimelineItemsAddsOneEntryPerRequest(): void
+    {
+        $this->login();
+        $ticket = $this->createItem('Ticket', ['name' => 't', 'content' => 'c', 'entities_id' => $this->getTestRootEntity(true)]);
+        $item = $this->getReservableItem();
+
+        $request_1 = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-02 09:00:00',
+            'end' => '2026-05-02 10:00:00',
+            'status' => TicketReservationRequest::STATUS_WAITING,
+        ]);
+        $request_2 = $this->createItem(TicketReservationRequest::class, [
+            'tickets_id' => $ticket->getID(),
+            'reservationitems_id' => $item->getID(),
+            'users_id' => Session::getLoginUserID(),
+            'begin' => '2026-05-02 11:00:00',
+            'end' => '2026-05-02 12:00:00',
+            'status' => TicketReservationRequest::STATUS_REFUSED,
+        ]);
+
+        $timeline = [];
+        TimelineManager::addTimelineItems(['item' => $ticket, 'timeline' => &$timeline]);
+
+        $key_1 = "TicketReservationRequest_{$request_1->getID()}";
+        $key_2 = "TicketReservationRequest_{$request_2->getID()}";
+        $this->assertNotSame($key_1, $key_2);
+        $this->assertArrayHasKey($key_1, $timeline);
+        $this->assertArrayHasKey($key_2, $timeline);
+        $this->assertCount(2, $timeline);
+    }
+
+    private function getReservableItem(): ReservationItem
+    {
+        $computer = $this->createItem('Computer', ['name' => 'test-computer', 'entities_id' => $this->getTestRootEntity(true)]);
+        return $this->createItem('ReservationItem', [
+            'itemtype' => 'Computer',
+            'items_id' => $computer->getID(),
+            'is_active' => 1,
+        ]);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39540
- Here is a brief description of what this PR does

Adds a **material reservation** capability to AdvancedForms: end users can reserve equipment directly from a GLPI form. The answer creates a ticket-driven reservation request that can be validated from the ticket timeline, and the actual reservation is created in the GLPI planning once approved (or immediately, in direct mode).

### Features

- **New question type "Material reservation"** equipment dropdown (grouped by type, loaded via AJAX and filtered by the allowed types configured on the question) plus start/end date pickers with real-time availability check and a list of the item's existing reservations.
- **New destination field "Pre-reservation"** on the Ticket destination, maps a reservation question to a reservation request, with a **"Require technician approval"** toggle:
  - **Approval mode (default):** the request appears in the ticket timeline as *pending*, with Approve / Refuse actions; the reservation is created on approval.
  - **Direct mode:** if the slot is still free at submission, the reservation is created and confirmed automatically; if it was taken meanwhile, the request is canceled and the requester is notified.
- **Ticket timeline integration** each request is shown in the timeline (equipment, time slot, status) with inline approve/refuse handling.
- **Notifications** requester is notified on creation, approval, refusal and slot-unavailable events; template and notifications are set up at install.
- **Reservation traceability** an approved request is linked to its reservation, and deleting the request cleans up the reservation.

## Screenshots (if appropriate):

- **Question configuration** "Material reservation" question type in the form editor (allowed equipment types)
<img width="990" height="236" alt="image" src="https://github.com/user-attachments/assets/dae4805d-b925-4762-b47e-01d70e07d870" />


- **End-user widget** equipment selection, date pickers, availability check and existing reservations
<img width="989" height="463" alt="image" src="https://github.com/user-attachments/assets/80873734-d9c7-4456-9d32-508ba05966ca" />


- **Destination config** "Pre-reservation" field with the "Require technician approval" toggle
<img width="622" height="256" alt="image" src="https://github.com/user-attachments/assets/93bc8f8c-fbf8-47ed-a843-b1eedc1a96e4" />


- **Ticket timeline (approval mode)** pending request with Approve / Refuse buttons
<img width="719" height="447" alt="image" src="https://github.com/user-attachments/assets/98a3d9ab-ab5a-44a6-838f-d4b612444e49" />


- **Ticket timeline (direct mode)** automatically confirmed reservation
<img width="719" height="447" alt="image" src="https://github.com/user-attachments/assets/512af8cc-bf3d-4ad1-a272-1186eeadea11" />