### PR TITLE
Fix Custom Dropdown filtering in table questions

### DIFF
--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -553,11 +553,22 @@ final class TableQuestion extends AbstractQuestionType implements
 
         global $DB;
 
+        $where = ['id' => $ids];
+
+        // GLPI 11 custom dropdown classes can share the same database table.
+        // Their system SQL criteria restrict rows to the current dropdown definition.
+        if (method_exists($itemtype, 'getSystemSQLCriteria')) {
+            $system_criteria = $itemtype::getSystemSQLCriteria();
+            if (is_array($system_criteria) && $system_criteria !== []) {
+                $where[] = $system_criteria;
+            }
+        }
+
         $map = [];
         foreach ($DB->request([
             'SELECT' => ['id', 'name'],
             'FROM'   => $item->getTable(),
-            'WHERE'  => ['id' => $ids],
+            'WHERE'  => $where,
         ]) as $row) {
             if (!is_array($row)) {
                 continue;
@@ -949,6 +960,15 @@ final class TableQuestion extends AbstractQuestionType implements
         }
 
         $where = [];
+
+        // GLPI 11 custom dropdown classes can share the same database table.
+        // Their system SQL criteria restrict rows to the current dropdown definition.
+        if (method_exists($itemtype, 'getSystemSQLCriteria')) {
+            $system_criteria = $itemtype::getSystemSQLCriteria();
+            if (is_array($system_criteria) && $system_criteria !== []) {
+                $where[] = $system_criteria;
+            }
+        }
 
         if ($item->maybeDeleted()) {
             $where['is_deleted'] = 0;


### PR DESCRIPTION
When using GLPI Custom Dropdowns inside table questions, all dropdown definitions display the same combined list of values.

This happens because all custom dropdowns use the same database table (`glpi_dropdowns_dropdowns`), but the current implementation does not apply the system criteria that distinguish each dropdown definition.

## Solution

This change updates the table question implementation to correctly filter Custom Dropdown values by applying the item's `getSystemSQLCriteria()` when:

- loading dropdown options;
- resolving stored values.

As a result, each Custom Dropdown now displays only the values that belong to its own definition.

Before 

<img width="290" height="339" alt="Снимок экрана 2026-07-21 143100" src="https://github.com/user-attachments/assets/fc015b93-514c-4d16-84e2-0909d5e6e3a1" />
<img width="211" height="335" alt="Снимок экрана 2026-07-21 143054" src="https://github.com/user-attachments/assets/04f9cd49-92bb-42f2-97ed-4e8b675d4367" />

After

<img width="226" height="238" alt="Screenshot 2026-07-31 163806" src="https://github.com/user-attachments/assets/7da6c20d-1124-44b2-a6b1-5f69ef69c6e1" />
<img width="250" height="266" alt="Screenshot 2026-07-31 163809" src="https://github.com/user-attachments/assets/56dcdc8f-2074-4845-aa97-d704016fdd77" />
