### PR TITLE
Support Plugin Fields in table questions

### DIFF
--- a/public/js/modules/AfTableQuestionConfig.js
+++ b/public/js/modules/AfTableQuestionConfig.js
@@ -58,6 +58,7 @@ export class AfTableQuestionConfig {
             container.querySelectorAll('[data-af-table-column]').forEach(row => {
                 AfTableQuestionConfig.#bindItemtypeVisibility(row);
                 AfTableQuestionConfig.#bindPatternVisibility(row);
+                AfTableQuestionConfig.#bindSubtypeVisibility(row);
             });
 
             if (addBtn && template) {
@@ -84,6 +85,7 @@ export class AfTableQuestionConfig {
         AfTableQuestionConfig.#initNewColumnSelect(newSelect, container.dataset.afTableColumnsContainer);
         AfTableQuestionConfig.#bindItemtypeVisibility(newRow);
         AfTableQuestionConfig.#bindPatternVisibility(newRow);
+        AfTableQuestionConfig.#bindSubtypeVisibility(newRow);
     }
 
     static #initNewColumnSelect(select, rand) {
@@ -162,6 +164,71 @@ export class AfTableQuestionConfig {
             window.$(typeSelect).on('change', update);
         } else {
             typeSelect.addEventListener('change', update);
+        }
+        update();
+    }
+
+
+    static #bindSubtypeVisibility(columnRow) {
+        const typeSelect = columnRow.querySelector('select[name*="[question_type]"]');
+        const subtypeRow = columnRow.querySelector('[data-af-subtype-row]');
+        const subtypeSelect = columnRow.querySelector('[data-af-subtype-select]');
+        const fieldSelect = columnRow.querySelector('[data-af-fields-field-select]');
+        if (!typeSelect || !subtypeRow || !subtypeSelect || !fieldSelect) { return; }
+
+        const container = columnRow.closest('[data-af-table-columns-container]');
+        let subtypeOptions = {};
+        let fieldsByBlock = {};
+        try { subtypeOptions = JSON.parse(container?.dataset.afSubtypeOptions ?? '{}'); } catch { subtypeOptions = {}; }
+        try { fieldsByBlock = JSON.parse(container?.dataset.afFieldsByBlock ?? '{}'); } catch { fieldsByBlock = {}; }
+
+        const populate = (select, options, selectedValue, placeholder) => {
+            select.replaceChildren();
+            const empty = document.createElement('option');
+            empty.value = '';
+            empty.textContent = placeholder;
+            select.appendChild(empty);
+            Object.entries(options || {}).forEach(([value, label]) => {
+                const option = document.createElement('option');
+                option.value = String(value);
+                option.textContent = String(label);
+                option.selected = String(value) === String(selectedValue ?? '');
+                select.appendChild(option);
+            });
+        };
+
+        const updateFields = () => {
+            const isFields = typeSelect.value.endsWith('PluginFieldsQuestionType');
+            const current = fieldSelect.dataset.afCurrentValue || fieldSelect.value;
+            const options = isFields ? (fieldsByBlock[String(subtypeSelect.value)] || {}) : {};
+            populate(fieldSelect, options, current, 'Select a field');
+            fieldSelect.disabled = !isFields || !subtypeSelect.value;
+            fieldSelect.classList.toggle('d-none', !isFields);
+            fieldSelect.dataset.afCurrentValue = '';
+        };
+
+        const update = () => {
+            const isFields = typeSelect.value.endsWith('PluginFieldsQuestionType');
+            const options = isFields ? (subtypeOptions.PluginFieldsQuestionType || {}) : {};
+            const oldValue = subtypeSelect.value;
+            populate(subtypeSelect, options, oldValue, 'Select a block');
+            const show = isFields && Object.keys(options).length > 0;
+            subtypeRow.classList.toggle('d-none', !show);
+            subtypeRow.classList.toggle('d-flex', show);
+            subtypeSelect.disabled = !show;
+            if (!show) {
+                fieldSelect.disabled = true;
+                fieldSelect.classList.add('d-none');
+            }
+            updateFields();
+        };
+
+        if (window.$) {
+            window.$(typeSelect).on('change', update);
+            window.$(subtypeSelect).on('change', updateFields);
+        } else {
+            typeSelect.addEventListener('change', update);
+            subtypeSelect.addEventListener('change', updateFields);
         }
         update();
     }

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -43,6 +43,7 @@ use Dropdown;
 use GLPIMailer;
 use Glpi\Application\View\TemplateRenderer;
 use Glpi\Form\Question;
+use Glpi\Form\Form;
 use Glpi\Form\QuestionType\AbstractQuestionType;
 use Glpi\Form\QuestionType\AbstractQuestionTypeActors;
 use Glpi\Form\QuestionType\AbstractQuestionTypeSelectable;
@@ -170,12 +171,16 @@ final class TableQuestion extends AbstractQuestionType implements
                 $type     = $col[TableQuestionConfig::COL_QUESTION_TYPE] ?? '';
                 $itemtype = $col[TableQuestionConfig::COL_ITEMTYPE] ?? '';
                 $pattern  = $col[TableQuestionConfig::COL_PATTERN] ?? '';
+                $subtype  = $col[TableQuestionConfig::COL_SUBTYPE] ?? '';
+                $field_id = $col[TableQuestionConfig::COL_FIELD_ID] ?? '';
                 return [
                     TableQuestionConfig::COL_NAME          => is_scalar($name) ? (string) $name : '',
                     TableQuestionConfig::COL_QUESTION_TYPE => is_scalar($type) ? (string) $type : '',
                     TableQuestionConfig::COL_REQUIRED      => (bool) ($col[TableQuestionConfig::COL_REQUIRED] ?? false),
                     TableQuestionConfig::COL_ITEMTYPE      => is_scalar($itemtype) ? (string) $itemtype : '',
                     TableQuestionConfig::COL_PATTERN       => is_scalar($pattern) ? (string) $pattern : '',
+                    TableQuestionConfig::COL_SUBTYPE        => is_scalar($subtype) ? (string) $subtype : '',
+                    TableQuestionConfig::COL_FIELD_ID       => is_scalar($field_id) ? (string) $field_id : '',
                 ];
             },
             array_filter((array) ($input[TableQuestionConfig::COLUMNS] ?? []), is_array(...)),
@@ -270,7 +275,7 @@ final class TableQuestion extends AbstractQuestionType implements
 
             foreach ($required_columns as $index => $name) {
                 $value = $row['col_' . $index] ?? '';
-                if (!is_scalar($value) || (string) $value === '') {
+                if (!$this->cellHasValue($value)) {
                     $result->addError($question, sprintf(
                         __('Row %1$s: the column "%2$s" is required.', 'advancedforms'),
                         $row_number,
@@ -350,12 +355,26 @@ final class TableQuestion extends AbstractQuestionType implements
     private function rowHasValue(array $row): bool
     {
         foreach ($row as $value) {
-            if ($value !== '' && $value !== null) {
+            if ($this->cellHasValue($value)) {
                 return true;
             }
         }
 
         return false;
+    }
+
+    private function cellHasValue(mixed $value): bool
+    {
+        if (is_array($value)) {
+            foreach ($value as $nested) {
+                if ($this->cellHasValue($nested)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return $value !== '' && $value !== null;
     }
 
     #[Override]
@@ -709,6 +728,51 @@ final class TableQuestion extends AbstractQuestionType implements
             ),
         ];
 
+        // Generic first-level subtype metadata exposed by GLPI question types.
+        $subtype_options = [];
+        foreach (QuestionTypesManager::getInstance()->getQuestionTypes() as $type) {
+            $subtypes = $type->getSubTypes();
+            if ($subtypes !== []) {
+                $subtype_options[$type::class] = $subtypes;
+            }
+        }
+
+        // Fields adds a second level (field inside block). Load active DOM
+        // blocks directly because getSubTypes() may be empty in this context.
+        $fields_by_block = [];
+        if (
+            class_exists('PluginFieldsQuestionType')
+            && class_exists('PluginFieldsContainer')
+        ) {
+            $container = new \PluginFieldsContainer();
+            $blocks = $container->find([
+                'is_active' => 1,
+                'type'      => 'dom',
+            ], 'name');
+
+            $fields_blocks = [];
+            foreach ($blocks as $block_id => $block_data) {
+                $block_id = (int) $block_id;
+                if ($block_id <= 0) {
+                    continue;
+                }
+
+                $fields = \PluginFieldsQuestionType::getFieldsFromBlock($block_id);
+                if (!is_array($fields) || $fields === []) {
+                    continue;
+                }
+
+                $fields_blocks[(string) $block_id] = (string) (
+                    $block_data['label']
+                    ?? $block_data['name']
+                    ?? ('Block #' . $block_id)
+                );
+                $fields_by_block[(string) $block_id] = $fields;
+            }
+
+            $subtype_options['PluginFieldsQuestionType'] = $fields_blocks;
+        }
+
         $twig = TemplateRenderer::getInstance();
         return $twig->render(
             '@advancedforms/editor/question_types/table_config.html.twig',
@@ -723,11 +787,16 @@ final class TableQuestion extends AbstractQuestionType implements
                 'COL_REQUIRED'             => TableQuestionConfig::COL_REQUIRED,
                 'COL_ITEMTYPE'             => TableQuestionConfig::COL_ITEMTYPE,
                 'COL_PATTERN'              => TableQuestionConfig::COL_PATTERN,
+                'COL_SUBTYPE'              => TableQuestionConfig::COL_SUBTYPE,
+                'COL_FIELD_ID'             => TableQuestionConfig::COL_FIELD_ID,
                 'MIN_ROWS'                 => TableQuestionConfig::MIN_ROWS,
                 'MAX_ROWS'                 => TableQuestionConfig::MAX_ROWS,
                 'itemtype_options'         => $itemtype_options,
                 'short_answer_fqcns'       => $short_answer_fqcns,
                 'short_answer_fqcns_json'  => json_encode($short_answer_fqcns),
+                'subtype_options'           => $subtype_options,
+                'subtype_options_json'      => json_encode($subtype_options),
+                'fields_by_block_json'      => json_encode($fields_by_block),
             ],
         );
     }
@@ -752,7 +821,29 @@ final class TableQuestion extends AbstractQuestionType implements
             $type     = $type_instances[$fqcn] ?? null;
             $itemtype = $col[TableQuestionConfig::COL_ITEMTYPE] ?? '';
 
-            if (is_a($fqcn, AbstractQuestionTypeActors::class, true)) {
+            if ($fqcn === 'PluginFieldsQuestionType' && class_exists('PluginFieldsField')) {
+                $field_id = (int) ($col[TableQuestionConfig::COL_FIELD_ID] ?? 0);
+                $field = $field_id > 0 ? \PluginFieldsField::getById($field_id) : false;
+                if ($field) {
+                    $field_data = $field->fields;
+                    $fields_itemtype = null;
+                    $field_type = (string) ($field_data['type'] ?? '');
+                    if (str_starts_with($field_type, 'dropdown')) {
+                        if ($field_type === 'dropdown') {
+                            $fields_itemtype = \PluginFieldsDropdown::getClassname((string) $field_data['name']);
+                        } elseif (str_starts_with($field_type, 'dropdown-')) {
+                            $fields_itemtype = substr($field_type, strlen('dropdown-'));
+                        }
+                    }
+                    $cell_map[$index] = [
+                        'mode'     => 'plugin_fields',
+                        'field'    => $field_data,
+                        'itemtype' => $fields_itemtype,
+                    ];
+                } else {
+                    $cell_map[$index] = ['mode' => 'input', 'input_type' => 'text'];
+                }
+            } elseif (is_a($fqcn, AbstractQuestionTypeActors::class, true)) {
                 $user_options     ??= $this->buildUserOptions();
                 $cell_map[$index]  = ['mode' => 'select', 'options' => $user_options];
             } elseif (is_a($fqcn, QuestionTypeUserDevice::class, true)) {
@@ -783,6 +874,7 @@ final class TableQuestion extends AbstractQuestionType implements
                 'config'           => $config,
                 'column_cell_map'  => $cell_map,
                 'ajax_limit_count' => $this->ajaxLimitCount(),
+                'fields_item'      => new Form(),
             ],
         );
     }

--- a/src/Model/QuestionType/TableQuestionConfig.php
+++ b/src/Model/QuestionType/TableQuestionConfig.php
@@ -55,6 +55,10 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
 
     public const COL_PATTERN       = 'pattern';
 
+    public const COL_SUBTYPE        = 'subtype';
+
+    public const COL_FIELD_ID       = 'field_id';
+
     /**
      * @param array<array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}> $columns
      */
@@ -81,6 +85,8 @@ final readonly class TableQuestionConfig implements JsonFieldInterface
                 self::COL_REQUIRED      => (bool) ($col[self::COL_REQUIRED] ?? false),
                 self::COL_ITEMTYPE      => (string) ($col[self::COL_ITEMTYPE] ?? ''),
                 self::COL_PATTERN       => (string) ($col[self::COL_PATTERN] ?? ''),
+                self::COL_SUBTYPE        => (string) ($col[self::COL_SUBTYPE] ?? ''),
+                self::COL_FIELD_ID       => (string) ($col[self::COL_FIELD_ID] ?? ''),
             ],
             array_filter($data[self::COLUMNS] ?? [], is_array(...)),
         ));

--- a/templates/editor/question_types/table_config.html.twig
+++ b/templates/editor/question_types/table_config.html.twig
@@ -71,6 +71,8 @@
                     class="mb-3"
                     data-af-table-columns-container="{{ rand }}"
                     data-af-short-answer-fqcns="{{ short_answer_fqcns_json|e('html_attr') }}"
+                    data-af-subtype-options="{{ subtype_options_json|e('html_attr') }}"
+                    data-af-fields-by-block="{{ fields_by_block_json|e('html_attr') }}"
                 >
                     {% for index, col in config.getColumns() %}
                         <div class="mb-2" data-af-table-column>
@@ -120,6 +122,30 @@
                                         </select>
                                     </div>
                                 {% endfor %}
+                                <div class="align-items-center gap-2 flex-shrink-0 d-none" data-af-subtype-row>
+                                                                <select
+                                                                    class="form-select form-select-sm"
+                                                                    style="width: 220px"
+                                                                    name="extra_data[columns][{{ index }}][{{ COL_SUBTYPE }}]"
+                                                                    data-af-subtype-select
+                                                                    disabled
+                                                                >
+                                                                    <option value="">{{ __('Select a block', 'fields') }}</option>
+                                                                    {% for value, label in subtype_options[col[COL_QUESTION_TYPE]]|default({}) %}
+                                                                        <option value="{{ value }}" {{ col[COL_SUBTYPE] == value ~ '' ? 'selected' : '' }}>{{ label }}</option>
+                                                                    {% endfor %}
+                                                                </select>
+                                                                <select
+                                                                    class="form-select form-select-sm"
+                                                                    style="width: 220px"
+                                                                    name="extra_data[columns][{{ index }}][{{ COL_FIELD_ID }}]"
+                                                                    data-af-fields-field-select
+                                                                    data-af-current-value="{{ col[COL_FIELD_ID] }}"
+                                                                    disabled
+                                                                >
+                                                                    <option value="">{{ __('Select a field', 'fields') }}</option>
+                                                                </select>
+                                                            </div>
                                 <label
                                     class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
                                     data-bs-toggle="tooltip"
@@ -146,6 +172,7 @@
                                     data-af-table-column-remove
                                 ></i>
                             </div>
+                            
                             <div class="mt-1" data-af-pattern-wrapper style="display: none">
                                 <input
                                     class="form-control form-control-sm"
@@ -207,6 +234,26 @@
                                     </select>
                                 </div>
                             {% endfor %}
+                            <div class="align-items-center gap-2 flex-shrink-0 d-none" data-af-subtype-row>
+                                                        <select
+                                                            class="form-select form-select-sm"
+                                                            style="width: 220px"
+                                                            name="extra_data[columns][__INDEX__][{{ COL_SUBTYPE }}]"
+                                                            data-af-subtype-select
+                                                            disabled
+                                                        >
+                                                            <option value="">{{ __('Select a block', 'fields') }}</option>
+                                                        </select>
+                                                        <select
+                                                            class="form-select form-select-sm"
+                                                            style="width: 220px"
+                                                            name="extra_data[columns][__INDEX__][{{ COL_FIELD_ID }}]"
+                                                            data-af-fields-field-select
+                                                            disabled
+                                                        >
+                                                            <option value="">{{ __('Select a field', 'fields') }}</option>
+                                                        </select>
+                                                    </div>
                             <label
                                 class="af-required-toggle cursor-pointer mb-0 flex-shrink-0"
                                 data-bs-toggle="tooltip"
@@ -232,6 +279,7 @@
                                 data-af-table-column-remove
                             ></i>
                         </div>
+                        
                         <div class="mt-1" data-af-pattern-wrapper style="display: none">
                             <input
                                 class="form-control form-control-sm"

--- a/templates/table_end_user.html.twig
+++ b/templates/table_end_user.html.twig
@@ -75,7 +75,28 @@
                     {% for col_index, col in columns %}
                         {% set cell = column_cell_map[col_index] %}
                         <td class="align-middle">
-                            {% if cell.mode == 'checkbox' %}
+                            {% if cell.mode == 'plugin_fields' %}
+                                {% set is_dropdown = cell.field.type starts with 'dropdown' %}
+                                {% set field_name = input_base ~ '[' ~ row_index ~ '][col_' ~ col_index ~ ']' ~ (is_dropdown ? '[items_id]' : '') %}
+                                {% if is_dropdown %}
+                                    <input type="hidden" name="{{ input_base }}[{{ row_index }}][col_{{ col_index }}][itemtype]" value="{{ cell.itemtype }}">
+                                {% endif %}
+                                {{ call('PluginFieldsField::prepareHtmlFields', [
+                                    [cell.field],
+                                    fields_item,
+                                    true,
+                                    true,
+                                    false,
+                                    {
+                                        'input_name'     : field_name,
+                                        'full_width'     : not (cell.field.type starts with 'dropdown' or cell.field.type == 'glpi_item'),
+                                        'no_label'       : true,
+                                        'mb'             : '',
+                                        'add_field_class': 'glpi-fields-plugin-question-type-glpi-item-field',
+                                        'comments'       : false
+                                    }
+                                ])|raw }}
+                            {% elseif cell.mode == 'checkbox' %}
                                 <div class="d-flex justify-content-center">
                                     <input
                                         type="checkbox"
@@ -133,7 +154,28 @@
             {% for col_index, col in columns %}
                 {% set cell = column_cell_map[col_index] %}
                 <td class="align-middle">
-                    {% if cell.mode == 'checkbox' %}
+                    {% if cell.mode == 'plugin_fields' %}
+                        {% set is_dropdown = cell.field.type starts with 'dropdown' %}
+                        {% set field_name = input_base ~ '[__ROW__][col_' ~ col_index ~ ']' ~ (is_dropdown ? '[items_id]' : '') %}
+                        {% if is_dropdown %}
+                            <input type="hidden" name="{{ input_base }}[__ROW__][col_{{ col_index }}][itemtype]" value="{{ cell.itemtype }}">
+                        {% endif %}
+                        {{ call('PluginFieldsField::prepareHtmlFields', [
+                            [cell.field],
+                            fields_item,
+                            true,
+                            true,
+                            false,
+                            {
+                                'input_name'     : field_name,
+                                'full_width'     : not (cell.field.type starts with 'dropdown' or cell.field.type == 'glpi_item'),
+                                'no_label'       : true,
+                                'mb'             : '',
+                                'add_field_class': 'glpi-fields-plugin-question-type-glpi-item-field',
+                                'comments'       : false
+                            }
+                        ])|raw }}
+                    {% elseif cell.mode == 'checkbox' %}
                         <div class="d-flex justify-content-center">
                             <input
                                 type="checkbox"


### PR DESCRIPTION
## Problem

Table questions allow selecting `PluginFieldsQuestionType`, but there is no way to configure the required Plugin Fields options.

As a result, users cannot select a block and a field, and Plugin Fields questions cannot be used correctly inside table columns.

## Solution

This change adds support for Plugin Fields in table question columns by:

- adding block selection;
- adding field selection based on the selected block;
- storing the selected block and field in the question configuration;
- rendering the configured Plugin Fields question in table rows.

Before

<img width="820" height="63" alt="bef" src="https://github.com/user-attachments/assets/d42d1f97-bdb6-4552-b2bc-46ead5752436" />
<img width="237" height="107" alt="bef (2)" src="https://github.com/user-attachments/assets/4f14fc96-4e6a-464d-8670-32c59ee3b7fe" />


After

<img width="825" height="67" alt="Screenshot 2026-07-31 165657" src="https://github.com/user-attachments/assets/d67ec43a-86df-4eda-8953-4490ee2482e1" />
<img width="822" height="76" alt="Screenshot 2026-07-31 165712" src="https://github.com/user-attachments/assets/fcedc5f9-1be4-4d8e-9fe8-43bd1f3c414b" />
<img width="370" height="446" alt="Screenshot 2026-07-31 165721" src="https://github.com/user-attachments/assets/2d159de4-0220-48e1-8327-d2bb442adf78" />
