### PR TITLE
Fix - Table question column type edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix Table question column type edge cases
+
 ## [1.3.0] - 2026-08-11
 
 ### Changed

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -817,6 +817,11 @@ final class TableQuestion extends AbstractQuestionType implements
                 }
             }
 
+            // Exclude question types with a sub-type selector (Fields plugin types)
+            if (!is_a($fqcn, QuestionTypeItem::class, true) && $type->getSubTypes() !== []) {
+                continue;
+            }
+
             $types[$fqcn] = $type->getName();
         }
 

--- a/src/Model/QuestionType/TableQuestion.php
+++ b/src/Model/QuestionType/TableQuestion.php
@@ -804,6 +804,7 @@ final class TableQuestion extends AbstractQuestionType implements
             HostnameQuestion::class,
             HiddenQuestion::class,
             LdapQuestion::class,
+            ReservationQuestion::class,
             self::class,
         ];
 
@@ -933,7 +934,8 @@ final class TableQuestion extends AbstractQuestionType implements
             return $options;
         }
 
-        $where = [];
+        /** @var array<string, mixed> $where */
+        $where = $itemtype::getSystemSQLCriteria();
 
         if ($item->maybeDeleted()) {
             $where['is_deleted'] = 0;

--- a/tests/Model/QuestionType/TableQuestionRenderingTest.php
+++ b/tests/Model/QuestionType/TableQuestionRenderingTest.php
@@ -33,15 +33,18 @@
 
 namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
 
+use Dropdown;
 use Glpi\Application\ImportMapGenerator;
 use Glpi\Form\Question;
 use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
 use Glpi\Form\QuestionType\QuestionTypeShortText;
 use Glpi\Tests\FormBuilder;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Session;
 use Symfony\Component\DomCrawler\Crawler;
 
 use function Safe\json_decode;
@@ -270,6 +273,53 @@ final class TableQuestionRenderingTest extends AdvancedFormsTestCase
     }
 
     /**
+     * Regression test: custom dropdown definitions all share the same database
+     * table (distinguished only by a foreign key to their definition), so a
+     * column's option list must be scoped to its own definition. Without that
+     * scoping, every "Item (custom dropdown)" column ends up offering entries
+     * from every custom dropdown definition instead of just its own.
+     */
+    public function testEachColumnOnlyShowsItsOwnCustomDropdownEntries(): void
+    {
+        $test1_definition = $this->initDropdownDefinition('Test1');
+        $test2_definition = $this->initDropdownDefinition('Test2');
+
+        $test1_class = $test1_definition->getDropdownClassName();
+        $test2_class = $test2_definition->getDropdownClassName();
+
+        Dropdown::resetItemtypesStaticCache();
+
+        $entity_id = Session::getActiveEntity();
+
+        $this->createItem($test1_class, [
+            'name'        => 'Item from Test1',
+            'entities_id' => $entity_id,
+        ]);
+        $this->createItem($test2_class, [
+            'name'        => 'Item from Test2',
+            'entities_id' => $entity_id,
+        ]);
+
+        $html = $this->render([
+            $this->column('Col1', QuestionTypeItemDropdown::class, itemtype: $test1_class),
+            $this->column('Col2', QuestionTypeItemDropdown::class, itemtype: $test2_class),
+        ]);
+
+        $crawler = new Crawler($html);
+        $selects = $crawler->filter('[data-af-table-body] [data-af-table-row] select');
+        $this->assertSame(2, $selects->count());
+
+        $col1_options = $selects->eq(0)->filter('option')->each(fn(Crawler $n): string => $n->text());
+        $col2_options = $selects->eq(1)->filter('option')->each(fn(Crawler $n): string => $n->text());
+
+        $this->assertContains('Item from Test1', $col1_options);
+        $this->assertNotContains('Item from Test2', $col1_options);
+
+        $this->assertContains('Item from Test2', $col2_options);
+        $this->assertNotContains('Item from Test1', $col2_options);
+    }
+
+    /**
      * @param array<array{name: string, question_type: string, required: bool, itemtype: string, pattern: string}> $columns
      * @return array<string, string> Decoded `data-af-pattern-cols` payload.
      */
@@ -324,12 +374,13 @@ final class TableQuestionRenderingTest extends AdvancedFormsTestCase
         string $fqcn,
         bool $required = false,
         string $pattern = '',
+        string $itemtype = '',
     ): array {
         return [
             TableQuestionConfig::COL_NAME          => $name,
             TableQuestionConfig::COL_QUESTION_TYPE => $fqcn,
             TableQuestionConfig::COL_REQUIRED      => $required,
-            TableQuestionConfig::COL_ITEMTYPE      => '',
+            TableQuestionConfig::COL_ITEMTYPE      => $itemtype,
             TableQuestionConfig::COL_PATTERN       => $pattern,
         ];
     }

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -162,6 +162,12 @@ final class TableQuestionTest extends AdvancedFormsTestCase
         $this->assertArrayNotHasKey(TreeCascadeDropdownQuestion::class, $types);
     }
 
+    public function testCompatibleTypesExcludesReservation(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey(ReservationQuestion::class, $types);
+    }
+
     /**
      * Regression test for types with custom sub-type selectors, which cannot
      * be represented as flat table column types and thus must be excluded.

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -33,6 +33,7 @@
 
 namespace GlpiPlugin\Advancedforms\Tests\Model\QuestionType;
 
+use Glpi\Form\Question;
 use Glpi\Form\Condition\ValueOperator;
 use Glpi\Form\QuestionType\QuestionTypeCheckbox;
 use Glpi\Form\QuestionType\QuestionTypeEmail;
@@ -181,13 +182,13 @@ final class TableQuestionTest extends AdvancedFormsTestCase
             }
 
             #[Override]
-            public function renderAdministrationTemplate(?\Glpi\Form\Question $question): string
+            public function renderAdministrationTemplate(?Question $question): string
             {
                 return '';
             }
 
             #[Override]
-            public function renderEndUserTemplate(?\Glpi\Form\Question $question, mixed $answer = null): string
+            public function renderEndUserTemplate(?Question $question, mixed $answer = null): string
             {
                 return '';
             }

--- a/tests/Model/QuestionType/TableQuestionTest.php
+++ b/tests/Model/QuestionType/TableQuestionTest.php
@@ -46,6 +46,13 @@ use GlpiPlugin\Advancedforms\Model\QuestionType\TreeCascadeDropdownQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestion;
 use GlpiPlugin\Advancedforms\Model\QuestionType\TableQuestionConfig;
 use GlpiPlugin\Advancedforms\Tests\AdvancedFormsTestCase;
+use Glpi\Form\QuestionType\AbstractQuestionType;
+use Glpi\Form\QuestionType\QuestionTypeCategoryInterface;
+use Glpi\Form\QuestionType\QuestionTypeItem;
+use Glpi\Form\QuestionType\QuestionTypeItemDropdown;
+use Glpi\Form\QuestionType\QuestionTypesManager;
+use GlpiPlugin\Advancedforms\Model\QuestionType\AdvancedCategory;
+use Override;
 
 final class TableQuestionTest extends AdvancedFormsTestCase
 {
@@ -152,6 +159,57 @@ final class TableQuestionTest extends AdvancedFormsTestCase
     {
         $types = $this->type->getCompatibleQuestionTypes();
         $this->assertArrayNotHasKey(TreeCascadeDropdownQuestion::class, $types);
+    }
+
+    /**
+     * Regression test for types with custom sub-type selectors, which cannot
+     * be represented as flat table column types and thus must be excluded.
+     */
+    public function testCompatibleTypesExcludesTypesWithSubTypes(): void
+    {
+        $fake_type = new class extends AbstractQuestionType {
+            #[Override]
+            public function getCategory(): QuestionTypeCategoryInterface
+            {
+                return new AdvancedCategory();
+            }
+
+            #[Override]
+            public function getSubTypes(): array
+            {
+                return ['fake' => 'Fake sub type'];
+            }
+
+            #[Override]
+            public function renderAdministrationTemplate(?\Glpi\Form\Question $question): string
+            {
+                return '';
+            }
+
+            #[Override]
+            public function renderEndUserTemplate(?\Glpi\Form\Question $question, mixed $answer = null): string
+            {
+                return '';
+            }
+        };
+
+        QuestionTypesManager::getInstance()->registerPluginQuestionType($fake_type);
+
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayNotHasKey($fake_type::class, $types);
+    }
+
+    /**
+     * QuestionTypeItem and QuestionTypeItemDropdown both declare a non-empty
+     * getSubTypes() but must stay selectable: Table
+     * already renders them through its own dedicated itemtype picker
+     * (TableQuestionConfig::COL_ITEMTYPE), independent of getSubTypes().
+     */
+    public function testCompatibleTypesIncludesItemAndItemDropdownDespiteSubTypes(): void
+    {
+        $types = $this->type->getCompatibleQuestionTypes();
+        $this->assertArrayHasKey(QuestionTypeItem::class, $types);
+        $this->assertArrayHasKey(QuestionTypeItemDropdown::class, $types);
     }
 
     public function testGetConfigKey(): void


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !43740
- Here is a brief description of what this PR does

Two related fixes for the Table question type's column configuration:

- Custom dropdown definitions (_Setup_ > _Dropdowns_) all share one database table, distinguished only by a foreign key to their definition. Table columns using a custom dropdown as their type queried that table without filtering by definition, so every column showed the combined entries of *all* custom dropdown definitions instead of just its own. Fixed by scoping the query with the definition's own SQL criteria.
- The column-type dropdown offered question types (**From Fields plugin**) that need an extra "sub type" selector (e.g. a two-level picker) that Table's flat column-type list has no way to represent. Selecting one silently fell back to a plain text input with no indication anything was wrong. These types are now excluded from the list, using the same generic core mechanism (`getSubTypes()`) other plugins would use for this, no plugin-specific code added.
- Also remove new Reservation question type from available type cause of it's specific handling 